### PR TITLE
Add c filtered security test files

### DIFF
--- a/c_filtered_100/compliant.c
+++ b/c_filtered_100/compliant.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-connection@v1.0 defects=0}
+
+void insecureConnectionCompliant() {
+    // Compliant: Opening a connection to a URL using HTTPS enforces SSL.
+    openUrl("https://example.com"); 
+}
+
+// {/fact}

--- a/c_filtered_100/compliant_1.c
+++ b/c_filtered_100/compliant_1.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=out-of-bounds-read@v1.0 defects=0}
+#include <stdio.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+int outOfBoundsReadCompliant() {
+    int arr[5] = {1, 2, 3, 4, 5};
+    int index = 2; // Choose a valid index within the array bounds
+    // Compliant: Ensure index is within bounds before accessing the array
+    if (index >= 0 && index < 5) {
+        int value = arr[index];
+        printf("Value: %d\n", value);
+    } else {
+        printf("Invalid index\n");
+    }
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/compliant_10.c
+++ b/c_filtered_100/compliant_10.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=random-fd-exhaustion@v1.0 defects=0}
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+int randomFdExhaustionCompliant() {
+    int fd;
+    int bytes_read;
+    char buf[16];
+    // Compliant: Limits the file descriptor use handling resource allocation
+    fd = open("/dev/urandom", 0);
+    memset(buf, 0, sizeof(buf));
+    bytes_read = read(fd, buf, sizeof(buf));
+    if (bytes_read != sizeof(buf)) {
+        return -1;
+    }
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/compliant_11.c
+++ b/c_filtered_100/compliant_11.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=bitwise-operator-on-signed-operand@v1.0 defects=0}
+#include <stdio.h>
+
+int bitwiseOperatoronSignedOperandCompliant(unsigned int i) {
+    // Compliant: Bitwise operator applied on unsigned operand. 
+    return 1 << i;
+}
+
+// {/fact}

--- a/c_filtered_100/compliant_12.c
+++ b/c_filtered_100/compliant_12.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-buffer-access@v1.0 defects=0}
+#include <stdio.h>
+#include <string.h>
+
+void insecureBufferAccessCompliant(char* src, char* dest, int dest_size) {
+  if (strlen(src) < dest_size) {
+    // Compliant: Bounds checking
+    strcat(dest, src);
+  }
+}
+// {/fact}

--- a/c_filtered_100/compliant_13.c
+++ b/c_filtered_100/compliant_13.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=divide-by-zero@v1.0 defects=0}
+struct OptionalInt divideByZeroCompliant(int a, int b) {
+    struct OptionalInt result;
+
+    if ((b == 0) || ((a == INT_MIN) && (b == -1))) {
+        result.has_value = 0; // Indicates failure
+        return result;
+    }
+    
+    result.has_value = 1;
+    // Compliant: Checking if the denominator is zero before dividing to avoid division by zero errors
+    result.value = a / b; 
+    return result; // Check correctly prevents divide-by-zero and signed integer overflows
+}
+// {/fact}

--- a/c_filtered_100/compliant_14.c
+++ b/c_filtered_100/compliant_14.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-block-delimitation@v1.0 defects=0}
+#include <stdio.h>
+#include <stdbool.h>
+
+bool condition = true;
+int incorrectBlockDelimitationCompliant()
+{
+   // Compliant: Actions performed within block
+   if (condition) {
+      firstActionInBlock();
+      secondAction();  
+      thirdAction();
+   }
+}
+// {/fact}

--- a/c_filtered_100/compliant_15.c
+++ b/c_filtered_100/compliant_15.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-strcat-fn@v1.0 defects=0}
+#include <strings.h>
+
+void insecureUseStrcatCompliant(char* src, char* dest, int dest_size) {
+    // Compliant: No hardcoded length
+    strncat(dest, src, dest_size - 1);
+    dest[dest_size - 1] = '\0';
+}
+// {/fact}

--- a/c_filtered_100/compliant_16.c
+++ b/c_filtered_100/compliant_16.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=improper-input-validation@v1.0 defects=0}
+#include <stdio.h>
+#include <string.h>
+
+void improperInputValidationCompliant(const char* input) {
+    char buffer[100]; // Assuming a maximum length of 100 characters
+
+    printf("Enter input: ");
+    scanf("%99s", buffer); // Limit input to 99 characters to leave space for null terminator
+
+    if(strlen(buffer) > 99) {
+        printf("Input exceeds maximum length\n");
+        return;
+    }
+    // Compliant: Validated input is copied to the provided const char* input
+    strcpy(input, buffer); 
+
+    printf("You entered: %s\n", input);
+}
+
+// {/fact}

--- a/c_filtered_100/compliant_17.c
+++ b/c_filtered_100/compliant_17.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=os-command-injection@v1.0 defects=0}
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+int osCommandInjectionCompliant(int argc, char** argv) {
+    char cat[] = "cat ";
+    char *command;
+    size_t commandLength;
+
+    commandLength = strlen(cat) + 1;
+    command = (char *) malloc(commandLength);
+    strncpy(command, cat, commandLength);
+
+    // Compliant: The (hardcoded) cat command will be executed
+    system(command);
+    return (0);
+}
+// {/fact}

--- a/c_filtered_100/compliant_18.c
+++ b/c_filtered_100/compliant_18.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-assignment@v1.0 defects=0}
+#include <stdio.h>
+
+void insecureAssignmentCompliant() {
+    // Compliant: Assignment with getValue
+    int x = getValue();
+    if (x) {
+      doSomething();
+    }
+}
+// {/fact}

--- a/c_filtered_100/compliant_19.c
+++ b/c_filtered_100/compliant_19.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=missing-break-in-switch@v1.0 defects=0}
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+void misingBreakInSwitchCompliant(char *data) {
+    int result = security_check(data);
+    // Compliant: All cases have break or exit
+    switch (result) {
+    case FAIL:
+        printf("Security check failed!\n");
+        exit(1);
+    case PASS:
+        printf("Security check passed.\n");
+        break;
+    default:
+        printf("Unknown error (%d), exiting...\n", result);
+        exit(1);
+    }
+}
+// {/fact}

--- a/c_filtered_100/compliant_2.c
+++ b/c_filtered_100/compliant_2.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-use-of-free@v1.0 defects=0}
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int incorrectUseOfFreeCompliant() {
+    NAME *var;
+    char buf[10];
+    var = (NAME *)malloc(sizeof(struct name));
+    free(var);
+    var = (NAME *)malloc(sizeof(struct name));
+    // Compliant: Variable is used after memory reallocation
+    var->func(var->myname);
+    return 0;
+}
+
+// {/fact}

--- a/c_filtered_100/compliant_20.c
+++ b/c_filtered_100/compliant_20.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-use-of-goto@v1.0 defects=0}
+#include <stdio.h>
+
+int IncorrectUseofGotoCompliant()
+{
+    FILE *file = fopen("example.txt", "r");
+    if (file == NULL) {
+        perror("Error opening file");
+        // Compliant: `goto` function is used inside conditional statements
+        goto cleanup;
+    }
+    // File processing code here
+    cleanup:
+        if (file != NULL) {
+            fclose(file);
+        }
+}
+// {/fact}

--- a/c_filtered_100/compliant_21.c
+++ b/c_filtered_100/compliant_21.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=return-stack-address@v1.0 defects=0}
+#include <stdio.h>
+#include <stdlib.h>
+
+// Compliant: Returning a heap-allocated address
+int* returnStackAddressCompliant() {
+    int* ptr = (int*)malloc(sizeof(int));
+    *ptr = 42;
+    return ptr;
+}
+// {/fact}

--- a/c_filtered_100/compliant_22.c
+++ b/c_filtered_100/compliant_22.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=null-pointer-dereference@v1.0 defects=0}
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <assert.h>
+
+void NullPointerDereferenceCompliant()
+{
+    int *ptr = NULL;
+    // Compliant: Checking for NULL before dereferencing
+    if (ptr != NULL)
+    {
+        int value = *ptr;
+    }
+}
+// {/fact}

--- a/c_filtered_100/compliant_23.c
+++ b/c_filtered_100/compliant_23.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=unused-assigned-variables@v1.0 defects=0}
+#include <stdio.h>
+
+int unusedAssignedVariablesCompliant(int y) {
+  // Compliant: no unnecessary assignment
+  int x = 200; 
+  return x + y;
+}
+// {/fact}

--- a/c_filtered_100/compliant_24.c
+++ b/c_filtered_100/compliant_24.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=unsafe-file-extension@v1.0 defects=0}
+#include <stdio.h>
+
+void unsafeFileExtensionCompliant() {
+    // Compliant: Safe extension used with fopen example
+    FILE* fileFopen = fopen("example.txt", "r");
+    if (fileFopen != NULL) {
+        printf("File opened successfully using fopen.\n");
+        fclose(fileFopen);
+    } else {
+        printf("Error: Failed to open the file using fopen.\n");
+    }
+}
+// {/fact}

--- a/c_filtered_100/compliant_25.c
+++ b/c_filtered_100/compliant_25.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=integer-overflow@v1.0 defects=0}
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+
+void integerOverflowCompliant(int *ptr, size_t offset) {
+    // Compliant: Safer pointer arithmetic with proper check
+    if (offset <= SIZE_MAX / sizeof(int))
+    {
+        int *result = ptr + offset;
+        // Use 'result'
+    }
+    else
+    {
+        fprintf(stderr, "Overflow detected in pointer arithmetic.\n");
+    }
+}
+// {/fact}

--- a/c_filtered_100/compliant_26.c
+++ b/c_filtered_100/compliant_26.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=path-traversal@v1.0 defects=0}
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+void pathTraversalComplaint() {
+    const char* zip_filename = "example.zip";
+    const char* output_dir = "output";
+
+    size_t len = strlen(zip_filename);
+    // Compliant: checking if the provided zip_filename ends with the ".zip" extension and if the output_dir exists before calling the extract_all_files function 
+    if ((len < 4 || strcmp(zip_filename + len - 4, ".zip") == 0) && (access(output_dir, F_OK) == 0)) {
+        extract_all_files(zip_filename, output_dir);
+    }
+}
+// {/fact}

--- a/c_filtered_100/compliant_27.c
+++ b/c_filtered_100/compliant_27.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-strtok-fn@v1.0 defects=0}
+#include <string.h>
+
+// Compliant: Secure - Copy first
+int insecureUseStrtokCompliant() {
+  char *static_str = "message,token";
+  char copy[128];
+  strsep_s(&copy, ",", 128);
+}
+// {/fact}

--- a/c_filtered_100/compliant_28.c
+++ b/c_filtered_100/compliant_28.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-comparison@v1.0 defects=0}
+#include <stdio.h>
+
+#define X509_V_OK 1
+
+#define X509_V_ERR_CERT_HAS_EXPIRED 1
+
+void improperCertificateValidationCompliant() {
+    char* ssl;
+    // Compliant: Proper verification done
+    X509 *cert = SSL_get_peer_certificate(ssl);
+    if (cert) {
+        int result = SSL_get_verify_result(ssl);
+        if (result == X509_V_OK) {
+            //...
+        }
+    }
+}
+// {/fact}

--- a/c_filtered_100/compliant_29.c
+++ b/c_filtered_100/compliant_29.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=file-system-access-toctou@v1.0 defects=0}
+#include <stdio.h>
+#include <pthread.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+pthread_mutex_t log_mutex;
+// Compliant: Fix race condition using mutex
+void fileSystemAccessToctouCompliant(char *msg) {
+  pthread_mutex_lock(&log_mutex);
+  FILE *fp = fopen("log.txt", "a");
+  fprintf(fp, "%s\n", msg);
+  fclose(fp);
+  pthread_mutex_unlock(&log_mutex);
+}
+// {/fact}

--- a/c_filtered_100/compliant_3.c
+++ b/c_filtered_100/compliant_3.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-temporary-file-or-directory@v1.0 defects=0}
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <unistd.h>
+
+int insecureTemporaryFileorDirectoryCompliant(char *tempData) {
+  // Compliant: The file will be opened in "wb+" mode, and will be automatically removed on normal program exit
+  FILE* f = tmpfile(); 
+  fputs(tempData, f);
+  fclose(f);
+  return 0;
+}
+// {/fact}

--- a/c_filtered_100/compliant_30.c
+++ b/c_filtered_100/compliant_30.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=deadlock-and-lock-inconsistency@v1.0 defects=0}
+#include <limits.h>
+#include <pthread.h>
+#include <stdio.h>
+
+pthread_mutex_t lock;
+
+void deadlockAndLockInconsistencyCompliant()
+{
+    // Compliant: This code dose not contains a potential deadlock or violate lock consistency due to incorrect lock ordering or nested locking.
+    pthread_mutex_init(&lock, NULL); // initialize mutex first
+    pthread_mutex_lock(&lock); // okay to lock now
+    // critical section
+    pthread_mutex_unlock(&lock);
+}
+// {/fact}

--- a/c_filtered_100/compliant_31.c
+++ b/c_filtered_100/compliant_31.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=missing-default-in-switch@v1.0 defects=0}
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+void missingDefaultInSwitchCompliant(char *data)
+{
+    int result = security_check(data);
+
+    // Compliant: Default is present
+    switch (result) {
+    case FAIL:
+        printf("Security check failed!\n");
+        exit(1);
+        break;
+    case PASS:
+        printf("Security check passed.\n");
+        break;
+    default:
+        printf("Unknown error (%d), exiting...\n", result);
+        exit(1);
+    }
+}
+// {/fact}

--- a/c_filtered_100/compliant_32.c
+++ b/c_filtered_100/compliant_32.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-use-of-sizeof@v1.0 defects=0}
+#include<stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+void incorrectUseofSizeofCompliant()
+{
+  int *ptr;
+  // Compliant: Correct use of sizeof to get the size of type and not the size of pointer
+  size_t size = sizeof(*ptr);
+}
+// {/fact}

--- a/c_filtered_100/compliant_33.c
+++ b/c_filtered_100/compliant_33.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=unchecked-return-value@v1.0 defects=0}
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+void uncheckedReturnValueCompliant() { 
+    const char* root_dir = "/jail/";
+    // Compliant: Checking the return value
+    if (chdir(root_dir) == -1) {
+      exit(-1);
+    }
+    
+}
+
+// {/fact}

--- a/c_filtered_100/compliant_34.c
+++ b/c_filtered_100/compliant_34.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incomplete-cleanup@v1.0 defects=0}
+#include <stdio.h>
+#include <stdlib.h>
+
+FILE *incompleteCleanupCompliant() {
+    FILE *f = fopen("example.txt", "r");
+    if (f == NULL) {
+        perror("Failed to open file");
+    }
+    // Compliant: File closed before returning
+    fclose(f);
+    return f;
+}
+// {/fact}

--- a/c_filtered_100/compliant_35.c
+++ b/c_filtered_100/compliant_35.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-use-ato-fn@v1.0 defects=0}
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+char* endptr;
+const char *buf = "";
+int incorrectUseAtoFnCompliant()
+{
+    // Compliant: secure function used
+    long num = strtol(buf, &endptr, 10);
+    if(endptr == buf) {
+        printf("Conversion failed\n");
+        return 1;
+    }
+    printf("Converted number: %ld\n", num);
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/compliant_36.c
+++ b/c_filtered_100/compliant_36.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=missing-authorization@v1.0 defects=0}
+#include <stdio.h>
+
+void misingAuthorizationComplaint(char* filename, char* user) {
+
+  // Compliant: Check if user has delete permission
+  if(checkPermissions(user, filename) == TRUE) {
+    remove(filename);
+  }
+}
+// {/fact}

--- a/c_filtered_100/compliant_37.c
+++ b/c_filtered_100/compliant_37.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=exposure-of-sensitive-information@v1.0 defects=0}
+int exposureofSensitiveInformationCompliant()
+{
+    // Compliant: https is used for secured url
+    char* https_url = "https://example.com";
+}
+
+// {/fact}

--- a/c_filtered_100/compliant_38.c
+++ b/c_filtered_100/compliant_38.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=logging-of-sensitive-information@v1.0 defects=0}
+#include <stdio.h>
+
+void loggingOfSensitiveInformationCompliant(const char *data) {
+    FILE *file = fopen("log.txt", "a");
+    if (file != NULL) {
+        // Redact sensitive information before logging
+        char redactedData[strlen(data) + 1];
+        strcpy(redactedData, data);
+        // Compliant: Replace sensitive information with placeholders or tokens
+        // For example, replace credit card numbers with "************"
+        // Modify this based on the type of sensitive data
+        redactCreditCardNumbers(redactedData); // Function to replace credit card numbers with ****
+
+        fputs(redactedData, file);
+        fputs("\n", file);
+        fclose(file);
+    }
+}
+// {/fact}

--- a/c_filtered_100/compliant_39.c
+++ b/c_filtered_100/compliant_39.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=out-of-bounds-write@v1.0 defects=0}
+#include <stdio.h>
+
+void outOfBoundsWriteCompliant(){
+
+  // Compliant: Ensuring correct loop bounds
+  int arr[3] = {1, 2, 3};
+  for (int i = 0; i < 3; ++i) {
+    arr[i] = i * 2; // Accessing indices within array bounds 
+  }
+}
+// {/fact}

--- a/c_filtered_100/compliant_4.c
+++ b/c_filtered_100/compliant_4.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=loose-file-permissions@v1.0 defects=0}
+#include <sys/stat.h>
+#include <fcntl.h>
+
+void looseFilePermissionsCompliant(){
+  
+  int fd;
+
+  // Compliant: The O_CREAT flag indicates that the file should be created if it doesn't exist.
+  open("myfile.txt", O_CREAT, S_IRWXU | S_IRWXG); 
+  // Compliant: further created files or directories will not have permissions set for "other group"
+  umask(S_IRWXO); 
+  
+}
+// {/fact}

--- a/c_filtered_100/compliant_40.c
+++ b/c_filtered_100/compliant_40.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=redundant-free-usage@v1.0 defects=0}
+#include <stdlib.h>
+#include <string.h>
+
+int redundantFreeUsageCompliant() {
+    char *var = malloc(sizeof(char) * 10);
+    free(var);
+    var = malloc(sizeof(char) * 10);
+    // Compliant: Use of free on variable after memory reallocation
+    free(var);
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/compliant_41.c
+++ b/c_filtered_100/compliant_41.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-gets-fn@v1.0 defects=0}
+#include <stdio.h>
+#include <string.h>
+
+int insecureUseGetsFnCompliant() {
+    char buf[10];
+    printf("Enter text: ");
+    // Compliant: Secure funcion used with specifying size limit
+    fgets(buf, sizeof(buf), stdin); 
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/compliant_42.c
+++ b/c_filtered_100/compliant_42.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-order-setuid-setgid@v1.0 defects=0}
+#include <stdio.h>
+#include <unistd.h>
+
+void incorrectOrderSetuidSetgidCompliant() {
+    // Compliant: setgid() is called before setuid()
+    setgid(getgid());
+    setuid(getuid());
+}
+// {/fact}

--- a/c_filtered_100/compliant_43.c
+++ b/c_filtered_100/compliant_43.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=improper-authentication@v1.0 defects=0}
+#include <stdio.h>
+#include <string.h>
+#define EXPECTED_HASH "$2y$10$8jKvuXVgC0cq2nPRw2XpCeUUiYrtguxna1xnmV4a88pQM/Pz3OxEi"
+
+void improperAuthenticationCompliant(char* password) {
+    // Hash the input password
+    char hashed_input[100];
+    // Use BCrypt to hash input
+    bcrypt_hash(hashed_input, password);
+
+    // Compliant: Validate hash against expected
+    if(strcmp(hashed_input, EXPECTED_HASH) == 0) {
+        printf("Access granted\n");
+    } else {
+        printf("Access denied\n");
+    }
+
+}
+// {/fact}

--- a/c_filtered_100/compliant_44.c
+++ b/c_filtered_100/compliant_44.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=improper-size-of-a-memory-buffer@v1.0 defects=0}
+int improperSizeOfAMemoryBufferCompliant()
+{
+    char array[10];
+    initialize(array);
+    // Compliant: size argument is same as the actual size of the buffer.
+    char *pos = memchr(array, '@', sizeof(array)); 
+
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/compliant_45.c
+++ b/c_filtered_100/compliant_45.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-comparison@v1.0 defects=0}
+#include <stdio.h>
+
+int incorrectComparisonCompliant()
+{
+	size_t uvar;
+
+	// Compliant: Avoiding comparison that can lead to unexpected behaviour
+	return 0;
+}
+// {/fact}

--- a/c_filtered_100/compliant_46.c
+++ b/c_filtered_100/compliant_46.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=sql-injection@v1.0 defects=0}
+#include <stdio.h>
+#include <mysql.h>
+#include <stdlib.h>
+#include <sqlite3.h>
+
+void sqlInjectionCompliant(int argc, char** argv) {
+    MYSQL *connection = mysql_init(NULL);
+    if (mysql_real_connect(connection, "localhost", "root", "root_passwd", NULL, 0, NULL, 0) == NULL) {
+        fprintf(stderr, "%s\n", mysql_error(connection));
+        mysql_close(connection);
+        exit(1);
+    }
+    char query[200];
+    char* name = argv[1];
+    char escaped_name[100];
+    mysql_real_escape_string(connection, escaped_name, name, strlen(name)); 
+    // Compliant: This is safe as `mysql_real_escape_string` escapes potentially malicious characters
+    sprintf(query, "SELECT * FROM users WHERE name = '%s'", escaped_name); 
+    mysql_query(connection, query);
+}
+// {/fact}

--- a/c_filtered_100/compliant_47.c
+++ b/c_filtered_100/compliant_47.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=sensitive-information-leak@v1.0 defects=0}
+#include <stdio.h>
+#include <stdlib.h>
+
+void sensitiveInformationLeakCompliant() {
+    // Compliant: check present before storing environment variables
+    char* key = getenv("APP_KEY");
+    if (key != NULL) {
+        fprintf(stdout, "APP_KEY value: %s\n", key);
+    }
+}
+
+// {/fact}

--- a/c_filtered_100/compliant_48.c
+++ b/c_filtered_100/compliant_48.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=use-of-uninitialized-variable@v1.0 defects=0}
+#include <stdio.h>
+
+int useOfUninitializedVariableCompliant(int flag, int b) {
+  int a;
+  if (flag) {
+    a = b;
+  } else {
+    a = 10;
+  }
+  // Compliant: Variable is used
+  return a; 
+}
+// {/fact}

--- a/c_filtered_100/compliant_49.c
+++ b/c_filtered_100/compliant_49.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-comparison@v1.0 defects=0}
+#include <stdio.h>
+
+int insecureComparisonCompliant(int a, int b) {
+    int result = 0;
+    // Compliant: Result is stored
+    result = a + b; 
+    return result;
+}
+// {/fact}

--- a/c_filtered_100/compliant_5.c
+++ b/c_filtered_100/compliant_5.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=expression-always-true@v1.0 defects=0}
+#include <stdio.h>
+#include <stdbool.h>
+
+void expresionAlwaysTrueCompliant(bool flag)
+{
+ int age = 33;
+  // Compliant: There is no direct use of boolean value 
+  if (!flag || age>=19) { 
+    firstActionInBlock();
+  }
+  else {
+    secondAction(); 
+  }
+}
+// {/fact}

--- a/c_filtered_100/compliant_6.c
+++ b/c_filtered_100/compliant_6.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=string-equality@v1.0 defects=0}
+#include <stddef.h>
+#include <string.h>
+
+char *s = "Hello";
+
+int stringEqualityCompliant()
+{
+    // Compliant: Checking actual value using strcmp
+    if (strcmp(s, "World") == 0) {
+        return -1;
+    }
+return 0;
+}
+// {/fact}

--- a/c_filtered_100/compliant_7.c
+++ b/c_filtered_100/compliant_7.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-of-chroot@v1.0 defects=0}
+#include <stdio.h>
+void insecureUseofChrootCompliant(){
+
+    const char* root_dir = "/jail/";
+
+    if(chdir(root_dir) == -1) {
+      exit(-1);
+    }
+    // Compliant: the current dir is changed to the jail and the results of both functions are checked
+    if(chroot(root_dir) == -1) {  
+      exit(-1);
+    }
+
+}
+// {/fact}

--- a/c_filtered_100/compliant_8.c
+++ b/c_filtered_100/compliant_8.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-memset@v1.0 defects=0}
+#include <string.h>
+#include <stdlib.h>
+#include <sys/_types/_errno_t.h>
+
+void insecureUseMemsetCompliant() {
+    char *buffer = malloc(1024);
+    // Compliant: Use of secure function.
+    errno_t res = memset_s(buffer, 1024, 0, 1024);
+    free(buffer);
+}
+// {/fact}

--- a/c_filtered_100/compliant_9.c
+++ b/c_filtered_100/compliant_9.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=file-race-bad@v1.0 defects=0}
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+void fileRaceBadCompliant(const char *check_file) {
+    // Compliant: File name is not used to do the file operations.
+    FILE *fe = fopen(check_file, "wx");
+    if (NULL == fe) {
+        /* Handle error */
+    }
+    /* Write to file */
+    if (fclose(fe) == EOF) {
+        /* Handle error */
+    }
+}
+// {/fact}

--- a/c_filtered_100/non-compliant.c
+++ b/c_filtered_100/non-compliant.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-connection@v1.0 defects=1}
+
+void insecureConnectionNonCompliant() {
+    // Noncompliant: Opening a connection to a URL using insecure HTTP enforces SSL.
+    openUrl("http://example.com"); 
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_1.c
+++ b/c_filtered_100/non-compliant_1.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=out-of-bounds-read@v1.0 defects=1}
+#include <stdio.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+int outOfBoundsReadNonCompliant() {
+    int arr[5] = {1, 2, 3, 4, 5};
+    int index = 5;
+    // Noncompliant: Array indexing out of bounds
+    int value = arr[index];
+    printf("Value: %d\n", value);
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_10.c
+++ b/c_filtered_100/non-compliant_10.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=random-fd-exhaustion@v1.0 defects=1}
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+int randomFdExhaustionNonCompliant() {
+    int fd;
+    char buf[16];
+    // Noncompliant: Does not handle resource allocation
+    fd = open("/dev/urandom", 0);
+    memset(buf, 0, sizeof(buf));
+    read(fd, buf, sizeof(buf));
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_11.c
+++ b/c_filtered_100/non-compliant_11.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=bitwise-operator-on-signed-operand@v1.0 defects=1}
+#include <stdio.h>
+
+int bitwiseOperatoronSignedOperandNonCompliant(int i) {
+    // Noncompliant: Bitwise operator applied on signed operand.
+    return 1 << i; // Noncompliant
+}
+
+// {/fact}

--- a/c_filtered_100/non-compliant_12.c
+++ b/c_filtered_100/non-compliant_12.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-buffer-access@v1.0 defects=1}
+#include <stdio.h>
+#include <string.h>
+
+int DST_BUFFER_SIZE = 120;
+
+int insecureBufferAccessNonCompliant() {
+    char str[DST_BUFFER_SIZE];
+    // Noncompliant: use of scanf function 
+    scanf("%s", str);
+    printf("%s", str);
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_13.c
+++ b/c_filtered_100/non-compliant_13.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=divide-by-zero@v1.0 defects=1}
+struct OptionalInt divideByZeroNonCompliant(int a, int b) {
+   struct OptionalInt result;
+  // While the following check correctly prevents signed integer overflows,
+  // it fails to prevent divide-by-zero errors. If `b` is equal to `0`, the
+  // application emits undefined behavior.
+  if ((a == INT_MIN) && (b == -1)) {
+    result.has_value = 0;
+    return result;
+  }
+  result.has_value = 1;
+  // Noncompliant: Performing division without checking if the denominator is zero will lead to division by zero errors
+  result.value = a / b; 
+  return result; // causes undefined behavior if `b` is zero
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_14.c
+++ b/c_filtered_100/non-compliant_14.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-block-delimitation@v1.0 defects=1}
+#include <stdio.h>
+#include <stdbool.h>
+
+bool condition = true;
+int incorrectBlockDelimitationNonCompliant()
+{
+  // Noncompliant: Actions performed outside block
+  if (condition)
+    firstActionInBlock();
+    secondAction(); 
+    thirdAction();
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_15.c
+++ b/c_filtered_100/non-compliant_15.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-strcat-fn@v1.0 defects=1}
+#include <strings.h>
+
+int DST_BUFFER_SIZE = 120;
+
+void insecureUseStrcatNonCompliant(char* src, char* dst) {
+    int n = DST_BUFFER_SIZE;
+    if ((dst != NULL) && (src != NULL) && (strlen(dst)+strlen(src)+1 <= n)) {
+        // Noncompliant: Does not affirm length
+        strcat(dst, src);
+        // Noncompliant: Hardcoded length passed
+        strncat(dst, src, 100);
+    }
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_16.c
+++ b/c_filtered_100/non-compliant_16.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=improper-input-validation@v1.0 defects=1}
+#include <stdio.h>
+#include <string.h>
+
+void improperInputValidationNonCompliant(const char* username) {
+    printf("Enter username: ");
+    fgets(username, sizeof(username), stdin);
+    // Noncompliant: Input validation is needed to prevent user input from exceeding the allocated memory for `username`.
+    printf("Hello, %s!\n", username);
+}
+
+// {/fact}

--- a/c_filtered_100/non-compliant_17.c
+++ b/c_filtered_100/non-compliant_17.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=os-command-injection@v1.0 defects=1}
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+int osCommandInjectionNonCompliant(int argc, char **argv) {
+    char cat[] = "cat ";
+    char *command;
+    size_t commandLength;
+
+    commandLength = strlen(cat) + strlen(argv[1]) + 1;
+    command = (char *) malloc(commandLength);
+    strncpy(command, cat, commandLength);
+
+    // Noncompliant: argv[1] is concatenated into command without validation
+    strncat(command, argv[1], (commandLength - strlen(cat)) );
+
+    // A potentially untrusted input is passed into `system` function
+    system(command);
+    return (0);
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_18.c
+++ b/c_filtered_100/non-compliant_18.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-assignment@v1.0 defects=1}
+#include <stdio.h>
+
+void insecureAssignmentNonCompliant() {
+  int x = 10;
+  int y = 20;
+  // Noncompliant: Assignment inside the condition
+  if (x = 5) {
+      // code block
+  }
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_19.c
+++ b/c_filtered_100/non-compliant_19.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=missing-break-in-switch@v1.0 defects=1}
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+void misingBreakInSwitchNonCompliant(char *data) {
+    int result = security_check(data);
+    // Noncompliant: First case has missing break or exit
+    switch (result) {
+    case FAIL:
+        printf("Security check failed!\n");
+    case PASS:
+        printf("Security check passed.\n");
+        break;
+    default:
+        printf("Unknown error (%d), exiting...\n", result);
+        exit(1);
+    }
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_2.c
+++ b/c_filtered_100/non-compliant_2.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-use-of-free@v1.0 defects=1}
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int incorrectUseOfFreeNonCompliant() {
+    NAME *var;
+    char buf[10];
+    var = (NAME *)malloc(sizeof(struct name));
+    free(var);
+    // Noncompliant: Variable is used after free
+    strcpy(buf, (char*)var);
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_20.c
+++ b/c_filtered_100/non-compliant_20.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-use-of-goto@v1.0 defects=1}
+#include <stdio.h>
+
+int IncorrectUseofGotoNonCompliant()
+{
+    int n;
+    // Noncompliant: `goto` function is recommended to use inside conditional statements to prevent unconditional jumps
+
+    return 0;
+ONE:
+    printf("went to one\n");
+    return 1;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_21.c
+++ b/c_filtered_100/non-compliant_21.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=return-stack-address@v1.0 defects=1}
+#include <stdio.h>
+#include <stdlib.h>
+
+// Noncompliant: Returning a stack address
+int* returnStackAddressNonCompliant() {
+    int localVar = 42;
+    return &localVar;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_22.c
+++ b/c_filtered_100/non-compliant_22.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=null-pointer-dereference@v1.0 defects=1}
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <assert.h>
+
+void NullPointerDereferenceNonCompliant()
+{
+    int *ptr;
+    // Noncompliant: Dereferencing uninitialized pointer
+    int value = *ptr;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_23.c
+++ b/c_filtered_100/non-compliant_23.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=unused-assigned-variables@v1.0 defects=1}
+#include <stdio.h>
+
+int unusedAssignedVariablesNonCompliant(int y) {
+  int x = 0;
+  // Noncompliant: dead store
+  x = 100; 
+  x = 200;
+  return x + y;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_24.c
+++ b/c_filtered_100/non-compliant_24.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=unsafe-file-extension@v1.0 defects=1}
+#include <stdio.h>
+
+void unsafeFileExtensionNonCompliant() {
+    // Noncompliant: Unsafe file extension used with fopen
+    FILE* fileFopen = fopen("example.bat", "rb");
+    if (fileFopen != NULL) {
+        printf("File opened successfully using fopen.\n");
+        fclose(fileFopen);
+    } else {
+        printf("Error: Failed to open the file using fopen.\n");
+    }
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_25.c
+++ b/c_filtered_100/non-compliant_25.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=integer-overflow@v1.0 defects=1}
+#include <stdlib.h>
+
+void integerOverflowNoncompliant(int *ptr, size_t offset) {
+    // Noncompliant: Perform pointer arithmetic without checking for potential integer overflow.
+    int *result = ptr + offset;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_26.c
+++ b/c_filtered_100/non-compliant_26.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=path-traversal@v1.0 defects=1}
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+void pathTraversalNonComplaint(int argc, char *argv[]) {
+  char filename[100];
+
+  strcpy(filename, argv[1]);
+  // Noncompliant: user input is used to construct file path
+  FILE *fp = fopen(filename, "r");
+  if(fp == NULL) {
+    printf("Error opening file\n");
+    return 1;
+  }
+  // Read file contents
+  fclose(fp);
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_27.c
+++ b/c_filtered_100/non-compliant_27.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-strtok-fn@v1.0 defects=1}
+#include <string.h>
+
+// Noncompliant: Insecure - Alter static literal
+void insecureUseStrtokNonCompliant() {
+    char *static_str = "message,token";
+    strtok(static_str, ",");
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_28.c
+++ b/c_filtered_100/non-compliant_28.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=improper-certificate-validation@v1.0 defects=1}
+#include <stdio.h>
+
+int improperCertificateValidationNonCompliant() {
+    char* ssl;
+    char* cert;
+    // Noncompliant: Missing verification
+    cert = SSL_get_peer_certificate(ssl); 
+
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_29.c
+++ b/c_filtered_100/non-compliant_29.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=file-system-access-toctou@v1.0 defects=1}
+#include <stdio.h>
+#include <pthread.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+// Function to write a log message
+// Has race condition without mutex!
+void fileSystemAccessToctouNonCompliant(char *msg) {
+  FILE *fp = fopen(filename, "a");
+    if (fp == NULL) {
+        perror("Error opening file");
+        exit(EXIT_FAILURE);
+    }
+
+    // Introduce a sleep to create a window for the race condition
+    sleep(1);
+
+    // Noncompliant: Write the message to the file
+    fprintf(fp, "%s\n", message);
+
+    fclose(fp);
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_3.c
+++ b/c_filtered_100/non-compliant_3.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-temporary-file-or-directory@v1.0 defects=1}
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <unistd.h>
+
+int insecureTemporaryFileorDirectoryNonCompliant(char *tempData) {
+  // Noncompliant: Insecure function used
+  char *path = tmpnam(NULL); 
+  FILE* f = fopen(path, "w");
+  fputs(tempData, f);
+  fclose(f);
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_30.c
+++ b/c_filtered_100/non-compliant_30.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=deadlock-and-lock-inconsistency@v1.0 defects=1}
+#include <limits.h>
+#include <pthread.h>
+#include <stdio.h>
+
+void deadlockAndLockInconsistencyNonComplaint() {
+    pthread_mutex_init(&lock, NULL);
+    // Noncompliant: Lock never acquired
+    pthread_mutex_unlock(&lock); 
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_31.c
+++ b/c_filtered_100/non-compliant_31.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=missing-default-in-switch@v1.0 defects=1}
+#include <stdio.h>
+#include <stdlib.h>
+
+void missingDefaultInSwitchNoncompliant(char *data) {
+    int result = security_check(data);
+
+    // Noncompliant: `switch` does not have `default` statement.
+    switch (result) {
+    case FAIL:
+        printf("Security check failed!\n");
+        break;
+    case PASS:
+        printf("Security check passed.\n");
+        break;
+    }
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_32.c
+++ b/c_filtered_100/non-compliant_32.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-use-of-sizeof@v1.0 defects=1}
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+void incorrectUseofSizeofNonCompliant()
+{
+  int *data;
+  // Noncompliant: Incorrect usage of sizeof
+  size_t const dataSize = sizeof data / sizeof(int); 
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_33.c
+++ b/c_filtered_100/non-compliant_33.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=unchecked-return-value@v1.0 defects=1}
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+void uncheckedReturnValueNotCompliant() {
+    const char* any_dir = "/any/";
+    // Noncompliant: missing check of the return value
+    chdir(any_dir); 
+}
+
+// {/fact}

--- a/c_filtered_100/non-compliant_34.c
+++ b/c_filtered_100/non-compliant_34.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incomplete-cleanup@v1.0 defects=1}
+#include <stdio.h>
+#include <stdlib.h>
+
+FILE *incompleteCleanupNonCompliant() {
+    FILE *f;
+    f = fopen("example.txt", "r");
+    if (f == NULL) {
+        perror("Failed to open file");
+    }
+    // Noncompliant: File not closed
+    return f;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_35.c
+++ b/c_filtered_100/non-compliant_35.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-use-ato-fn@v1.0 defects=1}
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+const char *buf = "";
+void incorrectUseAtoFnNonCompliant()
+{
+    // Noncompliant: Insecure function used
+    int i = atoi(buf);
+    printf("Converted integer: %d\n", i);
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_36.c
+++ b/c_filtered_100/non-compliant_36.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=missing-authorization@v1.0 defects=1}
+#include <stdio.h>
+#include <stdlib.h>
+
+void misingAuthorizationNonComplaint(char* filename) {
+  // Noncompliant: Deleting the file without any validation
+  remove(filename);
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_37.c
+++ b/c_filtered_100/non-compliant_37.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=exposure-of-sensitive-information@v1.0 defects=1}
+
+int exposureofSensitiveInformationNonCompliant()
+{
+    // Noncompliant: insecure protocal is used
+    char* ftp_url = "ftp://anonymous@example.com";
+    
+}
+
+// {/fact}

--- a/c_filtered_100/non-compliant_38.c
+++ b/c_filtered_100/non-compliant_38.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=logging-of-sensitive-information@v1.0 defects=1}
+#include <stdio.h>
+
+int loggingOfSensitiveInformationNonCompliant(int argc, char *argv[]) {
+    // Noncompliant: Logging sensitive information
+    printf(argv[1]);
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_39.c
+++ b/c_filtered_100/non-compliant_39.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=out-of-bounds-write@v1.0 defects=1}
+void outOfBoundsWriteNonCompliant(){
+    // Declaring an array named id_sequence with a size of 3 integers
+    int id_sequence[3];
+    id_sequence[0] = 123;
+    id_sequence[1] = 234; 
+    id_sequence[2] = 345;
+    // Noncompliant: Attempting to assign a value to the fourth element (out of bounds)
+    id_sequence[3] = 456; 
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_4.c
+++ b/c_filtered_100/non-compliant_4.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=loose-file-permissions@v1.0 defects=1}
+#include <sys/stat.h>
+#include <fcntl.h>
+
+void looseFilePermissionsNonCompliant(){
+
+  int fd;
+
+  // Noncompliant: The process set 777 permissions to this newly created file
+  open("myfile.txt", O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO); 
+
+  // Noncompliant: The process try to set 777 permissions to this newly created directory
+  mkdir("myfolder", S_IRWXU | S_IRWXG | S_IRWXO);  
+  
+  // Noncompliant: The process set 777 permissions to this file
+  chmod("myfile.txt", S_IRWXU | S_IRWXG | S_IRWXO);  
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_40.c
+++ b/c_filtered_100/non-compliant_40.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=redundant-free-usage@v1.0 defects=1}
+#include <stdlib.h>
+#include <string.h>
+
+int redundantFreeUsageNonCompliant(char *argv[]) {
+    char *buf1;
+    char *buf2;
+    buf1 = (char *) malloc(sizeof(char) * 10);
+    free(buf1);
+    buf2 = (char *) malloc(sizeof(char) * 5);
+    strncpy(buf2, argv[1], 1);
+    // Noncompliant: Redundent use of `free` on buf1 without memory reallocation
+    free(buf1);
+    free(buf2);
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_41.c
+++ b/c_filtered_100/non-compliant_41.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-gets-fn@v1.0 defects=1}
+#include <stdio.h>
+#include <string.h>
+
+int DST_BUFFER_SIZE = 120;
+
+int insecureUseGetsFnNonCompliant() {
+    char str[DST_BUFFER_SIZE];
+    // Noncompliant: gets is insecure
+    gets(str);
+    printf("%s", str);
+    return 0;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_42.c
+++ b/c_filtered_100/non-compliant_42.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-order-setuid-setgid@v1.0 defects=1}
+#include <stdio.h>
+#include <unistd.h>
+
+void incorrectOrderSetuidSetgidNonCompliant() {
+    // Noncompliant: setgid() is called after setuid()
+    setuid(getuid());
+    setgid(getgid());
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_43.c
+++ b/c_filtered_100/non-compliant_43.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=improper-authentication@v1.0 defects=1}
+#include <stdio.h>
+#include <string.h>
+
+// Hardcoded weak password
+#define PASSWORD "1234"
+
+// Login function
+void improperAuthenticationNonCompliant(char* password) {
+    // Noncompliant: Authentication missing
+    if(strcmp(password, PASSWORD) == 0) {
+        printf("Access granted\n");
+    } else {
+        printf("Access denied\n");
+    }
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_44.c
+++ b/c_filtered_100/non-compliant_44.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=improper-size-of-a-memory-buffer@v1.0 defects=1}
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+void improperSizeOfAMemoryBufferNonCompliant() {
+   int fd;
+   char buff[1024];
+   char path[] = "Documents/example.txt";
+
+   fd = open(path, O_RDONLY);
+
+   int size = 1027;
+   // Noncompliant: size argument exceeds the actual size of the buffer.
+   read(fd, buff, size);
+
+   printf("\n\n%s\n\n",buff);
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_45.c
+++ b/c_filtered_100/non-compliant_45.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=incorrect-comparison@v1.0 defects=1}
+#include <stdio.h>
+
+int incorrectComparisonNonCompliant() {
+	unsigned short int uvar;
+
+	// Noncompliant: This will always be true
+	if (uvar >= 0)
+		return 1;
+
+	return 0;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_46.c
+++ b/c_filtered_100/non-compliant_46.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=sql-injection@v1.0 defects=1}
+#include <stdio.h>
+#include <mysql.h>
+#include <stdlib.h>
+#include <sqlite3.h>
+
+void sqlInjectionNonCompliant(int argc, char** argv) {
+    MYSQL *connection = mysql_init(NULL);
+    if (mysql_real_connect(connection, "localhost", "root", "root_passwd", NULL, 0, NULL, 0) == NULL) {
+        fprintf(stderr, "%s\n", mysql_error(connection));
+        mysql_close(connection);
+        exit(1);
+    }
+    char query[200];
+    // Noncompliant: Untrusted argv passed into query
+    sprintf(query, "SELECT * FROM users WHERE name = '%s'", argv[1]); 
+    mysql_query(connection, query);
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_47.c
+++ b/c_filtered_100/non-compliant_47.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=sensitive-information-leak@v1.0 defects=1}
+#include <stdio.h>
+#include <stdlib.h>
+
+void sensitiveInformationLeakNonCompliant() {
+    // Noncompliant: no check present before storing environment variables
+    char* path = getenv("PATH");
+    char *buffer;
+    sprintf(buffer, "Cannot find exe on path: %s", path);
+}
+
+// {/fact}

--- a/c_filtered_100/non-compliant_48.c
+++ b/c_filtered_100/non-compliant_48.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=use-of-uninitialized-variable@v1.0 defects=1}
+#include <stdio.h>
+
+int useOfUninitializedVariableNonCompliant() {
+  int x;  // x is not initialized
+  // Noncompliant: x has grabage value
+  return x + 10; 
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_49.c
+++ b/c_filtered_100/non-compliant_49.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-comparison@v1.0 defects=1}
+#include <stdio.h>
+
+int insecureComparisonNonCompliant(int a, int b) {
+    int result = 0;
+    // Noncompliant: Result is not stored
+    a + b; 
+    return result;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_5.c
+++ b/c_filtered_100/non-compliant_5.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=expression-always-true@v1.0 defects=1}
+#include <stdio.h>
+#include <stdbool.h>
+
+void expressionAlwaysTrueNonCompliant()
+{
+  bool x = false;
+  // Noncompliant: Boolean value assigned to variable used in expression
+  if (!x || con) { 
+    firstActionInBlock();
+  }
+  else {
+    secondAction(); // never executed
+  }
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_6.c
+++ b/c_filtered_100/non-compliant_6.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=string-equality@v1.0 defects=1}
+#include <stddef.h>
+#include <string.h>
+
+int stringEqualityNonCompliant()
+{
+    char *s = "Hello";
+    // Noncompliant: Checking strin pointer instead of value
+    if (s == "World") {
+
+        return -1;
+    }
+return 0;
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_7.c
+++ b/c_filtered_100/non-compliant_7.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-of-chroot@v1.0 defects=1}
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+
+void insecureUseofChrootNoncompliant(){
+
+    const char* root_dir = "/jail/";
+    // Noncompliant: No chdir before or after chroot, and missing check of return value
+    chroot(root_dir); 
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_8.c
+++ b/c_filtered_100/non-compliant_8.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=insecure-use-memset@v1.0 defects=1}
+#include <string.h>
+#include <stdlib.h>
+
+void insecureUseMemsetNonCompliant() {
+    char *buffer = malloc(1024);
+    // Noncompliant: Use of insecure function.
+    memset(buffer, 0, 512);
+    free(buffer);
+}
+// {/fact}

--- a/c_filtered_100/non-compliant_9.c
+++ b/c_filtered_100/non-compliant_9.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// {fact rule=file-race-bad@v1.0 defects=1}
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+void fileRaceBadNonCompliant()
+{
+	// Noncompliant: File name is used to do the file operations.
+	int res = access("/tmp/userfile", R_OK);
+	if (res != 0)
+		printf("access");
+
+	int fd = open("/tmp/userfile", O_RDONLY);
+		// ...
+}
+// {/fact}


### PR DESCRIPTION
This PR adds filtered c security test files from the bug bot analysis.

## Changes
- Added 100 c security test files
- Files contain various security vulnerability patterns
- Organized in c_filtered_100/ directory

## Purpose
These files are part of a security analysis dataset for testing and research purposes.