### PR TITLE
Add go filtered security test files

### DIFF
--- a/go_filtered_100/BindToAllInterfaces.go
+++ b/go_filtered_100/BindToAllInterfaces.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+    "fmt"
+    "io"
+    "net"
+)
+
+// {fact rule=sensitive-information-leak@v1.0 defects=1}
+func bindToAllInterfacesNoncompliant() {
+	// Noncompliant: `0.0.0.0` IP address used
+	tel, err := net.Listen("tcp", "0.0.0.0:2000")
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+
+    for {
+        conn, err := tel.Accept()
+        if err != nil {
+            break
+        }
+        go func(c net.Conn) {
+            io.Copy(c, c)
+            c.Close()
+        }(conn)
+    }
+}
+// {/fact}
+
+// {fact rule=sensitive-information-leak@v1.0 defects=0}
+func bindToAllInterfacesCompliant() {
+	// Compliant: `192.168.1.101` IP address used
+	tel, err := net.Listen("tcp", "192.168.1.101:2000")
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+
+    for {
+        conn, err := tel.Accept()
+        if err != nil {
+            break
+        }
+        go func(c net.Conn) {
+            io.Copy(c, c)
+            c.Close()
+        }(conn)
+    }
+}
+// {/fact}

--- a/go_filtered_100/ChannelGuardedWithMutex.go
+++ b/go_filtered_100/ChannelGuardedWithMutex.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// {fact rule=best-practices@v1.0 defects=1}
+func channelGuardedWithMutexNoncompliant() {
+	var mutex = &sync.Mutex{}
+	msg := make(chan string)
+
+	go func() {
+		msg <- "ping"
+	}()
+
+	// Noncompliant: Channel guarded with mutex.
+	mutex.Lock()
+	message := <-msg
+	mutex.Unlock()
+	fmt.Println(message)
+}
+
+// {/fact}
+
+// {fact rule=best-practices@v1.0 defects=0}
+func channelGuardedWithMutexCompliant() {
+	msg := make(chan string)
+
+	go func() {
+		msg <- "ping"
+	}()
+
+	// Compliant: Channel is not guarded with mutex.
+	message := <-msg
+	fmt.Println(message)
+}
+
+// {/fact}

--- a/go_filtered_100/ConcatenationSqlInjection.go
+++ b/go_filtered_100/ConcatenationSqlInjection.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"database/sql"
+	"net/http"
+)
+
+// {fact rule=sql-injection@v1.0 defects=1}
+func concatenationSqlInjectionNoncompliant(database *sql.DB, request *http.Request) {
+	// Noncompliant: direct user input is used
+	database.Exec("SELECT * FROM Users WHERE City=" + request.FormValue("city"))
+}
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=0}
+func concatenationSqlInjectionCompliant(database *sql.DB) {
+	// Compliant: direct user input is not used
+	database.Exec("SELECT * FROM Users WHERE City=" + "Berlin")
+}
+// {/fact}

--- a/go_filtered_100/CrossSiteRequestForgery.go
+++ b/go_filtered_100/CrossSiteRequestForgery.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"html"
+	"net/http"
+)
+
+// {fact rule=cross-site-request-forgery@v1.0 defects=1}
+func crossSiteRequestForgeryNoncompliant(w http.ResponseWriter, r *http.Request) {
+	// Noncompliant: Sending a POST request with user input without CSRF protection.
+	fmt.Fprintf(w, "Go to: %s", html.EscapeString(r.URL.Path))
+}
+
+// {/fact}
+
+// {fact rule=cross-site-request-forgery@v1.0 defects=0}
+func crossSiteRequestForgeryCompliant(w http.ResponseWriter, r *http.Request, csrfToken string) {
+	csrfTokenFromForm := r.FormValue("csrf_token")
+	if csrfTokenFromForm != csrfToken {
+		http.Error(w, "Invalid CSRF token", http.StatusForbidden)
+		return
+	}
+
+	// Compliant: Sending a POST request with user input with CSRF protection.
+	fmt.Fprintf(w, "Go to: %s", html.EscapeString(r.URL.Path))
+}
+
+// {/fact}

--- a/go_filtered_100/DecompressionBomb.go
+++ b/go_filtered_100/DecompressionBomb.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"compress/zlib"
+	"fmt"
+	"io"
+	"os"
+)
+
+// {fact rule=denial-of-service@v1.0 defects=1}
+func decompressionBombNoncompliant() {
+	b := []byte{120, 156, 202, 72, 205, 201, 201, 215, 81, 40, 207,
+		47, 202, 73, 225, 2, 4, 0, 0, 255, 255, 33, 231, 4, 147}
+	bb := bytes.NewReader(b)
+	r, err := zlib.NewReader(bb)
+	if err != nil {
+		panic(err)
+	}
+	// Noncompliant: bytes read is not limited in `io.Copy()`.
+	out, err := io.Copy(os.Stdout, r)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("out: %v", out)
+}
+// {/fact}
+
+// {fact rule=denial-of-service@v1.0 defects=0}
+func decompressionBombCompliant() {
+	b := []byte{120, 156, 202, 72, 205, 201, 201, 215, 81, 40, 207,
+		47, 202, 73, 225, 2, 4, 0, 0, 255, 255, 33, 231, 4, 147}
+	bb := bytes.NewReader(b)
+	r, err := zlib.NewReader(bb)
+	if err != nil {
+		panic(err)
+	}
+	// Compliant: limiting the max bytes read using `io.LimitReader()`.
+	res := io.LimitReader(r, 8)
+	out, err := io.Copy(os.Stdout, res)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("out: %v", out)
+}
+// {/fact}

--- a/go_filtered_100/DeprecatedKeyGenerator.go
+++ b/go_filtered_100/DeprecatedKeyGenerator.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+)
+
+// {fact rule=deprecated-method@v1.0 defects=1}
+func deprecatedKeyGeneratorNoncompliant() {
+	// Noncompliant: Generate Private Key with deprecated method
+	pvk, err := rsa.GenerateMultiPrimeKey(rand.Reader, 3, 2048)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(pvk)
+}
+// {/fact}
+
+// {fact rule=deprecated-method@v1.0 defects=0}
+func deprecatedKeyGeneratorCompliant() {
+	// Compliant: Generate Private Key with proper method
+	pvk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(pvk)
+}
+// {/fact}

--- a/go_filtered_100/DirTraversal.go
+++ b/go_filtered_100/DirTraversal.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	net "net/http"
+)
+
+// {fact rule=path-traversal@v1.0 defects=1}
+func dirTraversalNoncompliant() {
+    // Noncompliant: Mounting the root directory '/' with `http.Dir`.
+	d := net.Dir("/")
+	f, err := d.Open("some file")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+}
+// {/fact}
+
+// {fact rule=path-traversal@v1.0 defects=0}
+func dirTraversalCompliant() {
+    // Compliant: Not mounting the root directory '/' with `http.Dir`.
+	d := net.Dir("/dir/newdir")
+	f, err := d.Open("some file")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+}
+// {/fact}

--- a/go_filtered_100/EqeqIsBad.go
+++ b/go_filtered_100/EqeqIsBad.go
@@ -1,0 +1,23 @@
+package main
+
+import "fmt"
+
+// {fact rule=best-practices@v1.0 defects=1}
+func eqeqIsBadNoncompliant() {
+	var s = "hello World !"
+	// Noncompliant: redundant comparison operation is used.
+	if s == s {
+		fmt.Println(s)
+	}
+}
+
+// {/fact}
+
+// {fact rule=best-practices@v1.0 defects=0}
+func eqeqIsBadCompliant() {
+	var s = "hello World !"
+	// Compliant:  redundant comparison operation is not used.
+	fmt.Println(s)
+}
+
+// {/fact}

--- a/go_filtered_100/ExportedLoopPointer.go
+++ b/go_filtered_100/ExportedLoopPointer.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+    "fmt"
+)
+
+// {fact rule=best-practices@v1.0 defects=1}
+func exportedLoopPointerNoncompliant() {
+    names := []string{"Jack", "Tom", "Sam", "Mark", "John"}
+    var fs []func()
+    for _, name := range names {
+        fs = append(fs, func() {
+            // Noncompliant: Loop pointer reference is shared across iterations.
+            fmt.Println(&name)
+        })
+    }
+}
+// {/fact}
+
+// {fact rule=best-practices@v1.0 defects=0}
+func exportedLoopPointerCompliant() {
+    names := []string{"Jack", "Tom", "Sam", "Mark", "John"}
+    var fs []func()
+    for _, name := range names {
+        // Compliant: Variable `name` is copied to a new variable within the loop before exporting.
+        name := name
+        fs = append(fs, func() {
+            fmt.Println(&name)
+        })
+    }
+}
+// {/fact}

--- a/go_filtered_100/GrpcServerInsecureConnection.go
+++ b/go_filtered_100/GrpcServerInsecureConnection.go
@@ -1,0 +1,35 @@
+package insecuregrpc
+
+import (
+	"crypto/x509"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"log"
+	"net"
+)
+
+// {fact rule=channel-accessible-by-non-endpoint@v1.0 defects=1}
+func grpcServerInsecureConnectionNoncompliant(listener net.Listener) {
+	// Noncompliant: credentials are not passed to grpc.NewServer
+	d := grpc.NewServer()
+	err := d.Serve(listener)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+}
+// {/fact}
+
+// {fact rule=channel-accessible-by-non-endpoint@v1.0 defects=0}
+func grpcServerInsecureConnectionCompliant(listener net.Listener, cp *x509.CertPool) {
+	creds := grpc.Creds(credentials.NewClientTLSFromCert(cp, ""))
+	// Compliant: credentials are passed to grpc.NewServer
+	d := grpc.NewServer(creds)
+	err := d.Serve(listener)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+}
+// {/fact}

--- a/go_filtered_100/HTTPTraceFileServerAsHandler.go
+++ b/go_filtered_100/HTTPTraceFileServerAsHandler.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+// {fact rule=exposure-through-directory-listing@v1.0 defects=1}
+func httpTraceFileServerAsHandlerNoncompliant() {
+	//Noncompliant: `http.FileServer` used
+	certFile := "YOUR_CERT_FILE"
+	keyFile := "YOUR_KEY_FILE"
+	fs := http.FileServer(http.Dir("/dir"))
+	log.Fatal(http.ListenAndServeTLS("192.168.1.101:2000", certFile, keyFile, fs))
+}
+
+// {/fact}
+
+// {fact rule=exposure-through-directory-listing@v1.0 defects=0}
+func httpTraceFileServerAsHandlerCompliant() {
+	//Compliant: `http.FileServer` not used
+	p := func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("<p>Hello!!!</p>"))
+	}
+	certFile := "YOUR_CERT_FILE"
+	keyFile := "YOUR_KEY_FILE"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", p)
+	log.Fatal(http.ListenAndServeTLS("192.168.1.101:2000", certFile, keyFile, mux))
+}
+
+// {/fact}

--- a/go_filtered_100/HardcodedEqTrueOrFalse.go
+++ b/go_filtered_100/HardcodedEqTrueOrFalse.go
@@ -1,0 +1,21 @@
+package main
+
+import "fmt"
+
+// {fact rule=best-practices@v1.0 defects=1}
+func hardcodedEqTrueOrFalseNoncompliant(num int){
+	// Noncompliant: `if` statement with hardcoded `true` condition.
+    if num == 5 && true {
+        fmt.Println("Hello")
+    }
+}
+// {/fact}
+
+// {fact rule=best-practices@v1.0 defects=0}
+func hardcodedEqTrueOrFalseCompliant(num int){
+    // Compliant: `if` statement without hardcoded condition.
+	if num == 5 {
+		fmt.Println("Hello")
+	}
+}
+// {/fact}

--- a/go_filtered_100/HiddenGoroutine.go
+++ b/go_filtered_100/HiddenGoroutine.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+)
+
+// {fact rule=best-practices@v1.0 defects=1}
+func hiddenGoroutineNoncompliant() {
+	// Noncompliant: Hidden goroutines inside functions.
+	go func() {
+		if 5%2 == 0 {
+			fmt.Println("5 is even")
+		} else {
+			fmt.Println("5 is odd")
+		}
+	}()
+}
+
+// {/fact}
+
+// {fact rule=best-practices@v1.0 defects=0}
+func hiddenGoroutineCompliant() {
+	// Compliant: There is other operations along with goroutine.
+	if num := 17; num < 0 {
+		fmt.Println(num, "is negative")
+	}
+	go func() {
+		if 5%2 == 0 {
+			fmt.Println("5 is even")
+		} else {
+			fmt.Println("5 is odd")
+		}
+	}()
+	if 8%2 == 0 {
+		fmt.Println("8 is even")
+	}
+}
+
+// {/fact}

--- a/go_filtered_100/HttpCookieSecureNotset.go
+++ b/go_filtered_100/HttpCookieSecureNotset.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"net/http"
+)
+
+// {fact rule=insecure-cookie@v1.0 defects=1}
+func httpCookieSecureNotsetNoncompliant(w http.ResponseWriter, name, value string) {
+	// Noncompliant: `Secure` not set
+	cookie := http.Cookie{
+		HttpOnly: true,
+		Name:     name,
+		Value:    value,
+	}
+	http.SetCookie(w, &cookie)
+}
+
+// {/fact}
+
+// {fact rule=insecure-cookie@v1.0 defects=0}
+func httpCookieSecureNotsetCompliant(w http.ResponseWriter, name, value string) {
+	// Noncompliant: `Secure` set true
+	cookie := http.Cookie{
+		Secure:   true,
+		HttpOnly: true,
+		Name:     name,
+		Value:    value,
+	}
+	http.SetCookie(w, &cookie)
+}
+
+// {/fact}

--- a/go_filtered_100/HttpListenandservetls.go
+++ b/go_filtered_100/HttpListenandservetls.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+    "net/http"
+)
+
+// {fact rule=insecure-connection@v1.0 defects=1}
+func httpListenandservetlsNoncompliant() {
+    handler := func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "text/plain")
+        w.Write([]byte("Hello!"))
+    }
+    http.HandleFunc("/test", handler)
+    // Noncompliant: http.ListenAndServe is used (without certificate and key)
+    http.ListenAndServe("192.168.1.101:2000", nil)
+}
+// {/fact}
+
+// {fact rule=insecure-connection@v1.0 defects=0}
+func httpListenandservetlsCompliant(certFile string, keyFile string) {
+    handler := func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "text/plain")
+        w.Write([]byte("Hello!"))
+    }
+    http.HandleFunc("/test", handler)
+    // Compliant: `http.ListenAndServeTLS` is used (with certificate and key)
+    http.ListenAndServeTLS("192.168.1.101:2000", certFile, keyFile, nil)
+}
+// {/fact}

--- a/go_filtered_100/ImproperCertificateValidation.go
+++ b/go_filtered_100/ImproperCertificateValidation.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+func improperCertificateValidationNoncompliant(authReq *http.Request) *http.Response {
+	// {fact rule=improper-certificate-validation@v1.0 defects=1}
+	// Noncompliant : `InsecureSkipVerify` parameter set to true
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS13,
+		},
+	}
+	// {/fact}
+	client := &http.Client{Transport: tr}
+	res, _ := client.Do(authReq)
+	return res
+}
+
+func improperCertificateValidationCompliant(authReq *http.Request) *http.Response {
+	// {fact rule=improper-certificate-validation@v1.0 defects=0}
+	// Compliant : `InsecureSkipVerify` parameter set to false
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: false,
+			MinVersion:         tls.VersionTLS13,
+		},
+	}
+	// {/fact}
+	client := &http.Client{Transport: tr}
+	res, _ := client.Do(authReq)
+	return res
+}

--- a/go_filtered_100/InsecureCryptography.go
+++ b/go_filtered_100/InsecureCryptography.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"crypto/md5"
+	"crypto/sha256"
+	"fmt"
+)
+
+type User struct {
+	password string
+}
+
+func (user *User) setPassword(password string) {
+	user.password = password
+}
+
+// {fact rule=insecure-cryptography@v1.0 defects=1}
+func insecureCryptographyNoncompliant(user *User, passText string) {
+	data := []byte(passText)
+	// Noncompliant : md5 used as password.
+	hash := md5.Sum(data)
+	password := fmt.Sprintf("%x", hash)
+	user.setPassword(password)
+}
+
+// {/fact}
+
+// {fact rule=insecure-cryptography@v1.0 defects=0}
+func insecureCryptographyCompliant(user *User, passText string) {
+	data := []byte(passText)
+	// Compliant: sha256 used as password.
+	hash := sha256.Sum256(data)
+	password := fmt.Sprintf("%x", hash)
+	user.setPassword(password)
+}
+
+// {/fact}

--- a/go_filtered_100/InsecureFilePermissions.go
+++ b/go_filtered_100/InsecureFilePermissions.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func insecureFilePermissionsNoncompliant() {
+    // {fact rule=insecure-file-permissions@v1.0 defects=1}
+	// Noncompliant: `0777` grants read, write and execute permission to owner, group and others.
+	err := os.Chmod("/project/src/information.txt", 0777)
+	if err != nil {
+		fmt.Println("Error occurred while changing file permission:", err)
+		return
+	}
+	fmt.Println("File permission changed successfully.")
+    // {/fact}
+}
+
+func insecureFilePermissionsCompliant() {
+    // {fact rule=insecure-file-permissions@v1.0 defects=0}
+	// Compliant: File permissions is set to `0400` which provides read permission to file owner only.
+	err := os.Chmod("/project/src/information.txt", 0400)
+	if err != nil {
+		fmt.Println("Error occurred while changing file permission:", err)
+		return
+	}
+	fmt.Println("File permission changed successfully.")
+	// {/fact}
+}

--- a/go_filtered_100/IntegerOverflow.go
+++ b/go_filtered_100/IntegerOverflow.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// {fact rule=integer-overflow@v1.0 defects=1}
+func integerOverflowNoncompliant() {
+	value, err := strconv.Atoi("-2147483649")
+	if err != nil {
+		panic(err)
+	}
+	// Noncompliant: `int32` used with big value.
+	newValue := int32(value)
+	fmt.Println(newValue)
+}
+// {/fact}
+
+// {fact rule=integer-overflow@v1.0 defects=0}
+func integerOverflowCompliant() {
+	value, err := strconv.Atoi("2147483647")
+	if err != nil {
+		panic(err)
+	}
+	// Compliant:  `int32` used with small value.
+	newValue := int32(value)
+	fmt.Println(newValue)
+}
+// {/fact}

--- a/go_filtered_100/JwtGoParseUnverified.go
+++ b/go_filtered_100/JwtGoParseUnverified.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+    "fmt"
+    "github.com/dgrijalva/jwt-go"
+)
+
+// {fact rule=protection-mechanism-failure@v1.0 defects=1}
+func jwtGoParseUnverifiedNoncompliant() {
+    validToken := "valid.token.string"
+    // Noncompliant: `ParseUnverified` used in here.
+    token, _, err := new(jwt.Parser).ParseUnverified(validToken, jwt.MapClaims{})
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+    fmt.Println(token)
+}
+// {/fact}
+
+// {fact rule=protection-mechanism-failure@v1.0 defects=0}
+func jwtGoParseUnverifiedCompliant() {
+    validToken := "valid.token.string"
+    keyFunc := func(token *jwt.Token) (interface{}, error){
+        return []byte("your-secret-key"), nil
+    }
+    // Compliant: `ParseWithClaims` used in here.
+    token, err := new(jwt.Parser).ParseWithClaims(validToken, jwt.MapClaims{}, keyFunc)
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+    fmt.Println(token)
+}
+// {/fact}

--- a/go_filtered_100/LambdaClientReuse.go
+++ b/go_filtered_100/LambdaClientReuse.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+var cfg, err = config.LoadDefaultConfig(context.TODO())
+var s3Client = s3.NewFromConfig(cfg)
+
+// {fact rule=lambda-client-reuse@v1.0 defects=1}
+func LambdaHandlerNoncompliant(ctx context.Context) (string, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		log.Fatalf("Error loading AWS config: %v", err)
+	}
+	// Noncompliant: Created S3 client inside lambda handler.
+	s3Client := s3.NewFromConfig(cfg)
+
+	result, err := s3Client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	if err != nil {
+		log.Fatalf("Error listing buckets: %v", err)
+	}
+
+	var bucketNames []string
+	for _, bucket := range result.Buckets {
+		if bucket.Name != nil {
+			bucketNames = append(bucketNames, *bucket.Name)
+		}
+	}
+
+	message := fmt.Sprintf("S3 Buckets: %v", bucketNames)
+	return message, nil
+}
+
+// {/fact}
+
+// {fact rule=lambda-client-reuse@v1.0 defects=0}
+func LambdaHandlerCompliant(ctx context.Context) (string, error) {
+	result, err := s3Client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	if err != nil {
+		log.Fatalf("Error listing buckets: %v", err)
+	}
+
+	var bucketNames []string
+	for _, bucket := range result.Buckets {
+		if bucket.Name != nil {
+			bucketNames = append(bucketNames, *bucket.Name)
+		}
+	}
+
+	message := fmt.Sprintf("S3 Buckets: %v", bucketNames)
+	return message, nil
+}
+
+// {/fact}

--- a/go_filtered_100/MissingPagination.go
+++ b/go_filtered_100/MissingPagination.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+import "log"
+import "github.com/aws/aws-sdk-go-v2/config"
+import "github.com/aws/aws-sdk-go-v2/aws"
+import "github.com/aws/aws-sdk-go-v2/service/s3"
+
+// {fact rule=missing-pagination@v1.0 defects=1}
+func missingPaginationNoncompliant() {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		log.Printf("error: %v", err)
+		return
+	}
+
+	client := s3.NewFromConfig(cfg)
+
+	params := &s3.ListObjectsV2Input{
+		Bucket: aws.String("my-bucket"),
+	}
+
+	// Noncompliant: Pagination is missing.
+	output, err := client.ListObjectsV2(context.TODO(), params)
+	if err != nil {
+		log.Printf("error: %v", err)
+	}
+	fmt.Println(output)
+}
+
+// {/fact}
+
+// {fact rule=missing-pagination@v1.0 defects=0}
+func missingPaginationCompliant() {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		log.Printf("error: %v", err)
+		return
+	}
+
+	client := s3.NewFromConfig(cfg)
+
+	params := &s3.ListObjectsV2Input{
+		Bucket: aws.String("my-bucket"),
+	}
+
+	// Compliant: `NewListObjectsV2Paginator` is used.
+	paginator := s3.NewListObjectsV2Paginator(client, params, func(o *s3.ListObjectsV2PaginatorOptions) {
+		o.Limit = 10
+	})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			log.Printf("error: %v", err)
+			return
+		}
+		fmt.Println(output)
+	}
+}
+
+// {/fact}

--- a/go_filtered_100/NilPointerDereference.go
+++ b/go_filtered_100/NilPointerDereference.go
@@ -1,0 +1,23 @@
+package main
+
+import "fmt"
+
+// {fact rule=null-pointer-dereference@v1.0 defects=1}
+func nilPointerDereferenceNoncompliant() {
+    var ptr *int
+    // Noncompliant: Accessing memory address that is not initialized.
+    fmt.Println(*ptr)
+}
+// {/fact}
+
+// {fact rule=null-pointer-dereference@v1.0 defects=0}
+func nilPointerDereferenceCompliant() {
+    var ptr *int
+    if ptr != nil {
+        // Compliant: Nil check before accessing memory address.
+        fmt.Println(*ptr)
+    } else {
+        fmt.Println("Pointer is nil")
+    }
+}
+// {/fact}

--- a/go_filtered_100/NotRecommendedApis.go
+++ b/go_filtered_100/NotRecommendedApis.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// {fact rule=not-recommended-apis@v1.0 defects=1}
+func notRecommendedApisNoncompliant() {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		log.Fatal("Unable to load SDK config, ", err)
+	}
+
+	client := s3.NewFromConfig(cfg)
+
+	// Noncompliant: `ListObjects` is not recommended to use.
+	respD, errD := client.ListObjects(context.TODO(), &s3.ListObjectsInput{Bucket: aws.String("your-bucket-name")})
+
+	if errD != nil {
+		log.Fatal("Error:", errD)
+	}
+	fmt.Println(respD)
+}
+
+// {/fact}
+
+// {fact rule=not-recommended-apis@v1.0 defects=0}
+func notRecommendedApisCompliant() {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		log.Fatal("Unable to load SDK config, ", err)
+	}
+
+	client := s3.NewFromConfig(cfg)
+
+	// Compliant: `ListObjectsV2Paginator` is used instead of `ListObjects`.
+	paginator := s3.NewListObjectsV2Paginator(client,
+		&s3.ListObjectsV2Input{
+			Bucket: aws.String("your-bucket-name"),
+		},
+		func(o *s3.ListObjectsV2PaginatorOptions) {
+			o.Limit = 10
+		})
+
+	for paginator.HasMorePages() {
+		respD, errD := paginator.NextPage(context.TODO())
+		if errD != nil {
+			log.Printf("error: %v", err)
+			return
+		}
+		fmt.Println(respD)
+	}
+}
+
+// {/fact}

--- a/go_filtered_100/PprofDebugExposure.go
+++ b/go_filtered_100/PprofDebugExposure.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+)
+
+// {fact rule=detect-activated-debug-feature@v1.0 defects=1}
+func pprofDebugExposureNoncompliant() {
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Not Ok")
+	})
+	certFile := "YOUR_CERT_FILE"
+	keyFile := "YOUR_KEY_FILE"
+	// Noncompliant: pprof is enabled.
+	log.Fatal(http.ListenAndServeTLS("192.168.1.101:2000", certFile, keyFile, nil))
+}
+
+// {/fact}
+
+// {fact rule=detect-activated-debug-feature@v1.0 defects=0}
+func pprofDebugExposureCompliant() {
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Ok")
+	})
+	certFile := "YOUR_CERT_FILE"
+	keyFile := "YOUR_KEY_FILE"
+	serveMux := http.NewServeMux()
+	// Compliant: pprof is disabled.
+	log.Fatal(http.ListenAndServeTLS("192.168.1.101:2000", certFile, keyFile, serveMux))
+}
+
+// {/fact}

--- a/go_filtered_100/ResourceLeak.go
+++ b/go_filtered_100/ResourceLeak.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+   "fmt"
+   "log"
+   "os"
+)
+
+// {fact rule=resource-leak@v1.0 defects=1}
+func resourceLeakNoncompliant() {
+    // Noncompliant: File is not closed properly.
+    file, err := os.Open("data.txt")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    data := make([]byte, 1024)
+    _, err = file.Read(data)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println("Data processing complete.")
+}
+// {/fact}
+
+// {fact rule=resource-leak@v1.0 defects=0}
+func resourceLeakCompliant() {
+    // Compliant: File is closed properly.
+    file, err := os.Open("data.txt")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer file.Close()
+
+    data := make([]byte, 1024)
+    _, err = file.Read(data)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println("Data processing complete.")
+}
+// {/fact}

--- a/go_filtered_100/S3VerifyBucketOwner.go
+++ b/go_filtered_100/S3VerifyBucketOwner.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"log"
+	"os"
+)
+
+const (
+	awsRegion           = "your-aws-region"
+	bucketName          = "your-bucket-name"
+	objectKey           = "your-object-key"
+	expectedBucketOwner = "expected-bucket-owner-id"
+)
+
+// {fact rule=s3-verify-bucket-owner@v1.0 defects=1}
+func s3VerifyBucketOwnerNoncompliant() {
+	fileName := "YOUR_PATH"
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(awsRegion),
+	})
+	if err != nil {
+		log.Fatal("Error:", err)
+		return
+	}
+	s3Client := s3.New(sess)
+	file, err := os.Open(fileName)
+	if err != nil {
+		log.Printf("Couldn't open file %v to upload. Error: %v\n", fileName, err)
+	}
+	defer file.Close()
+	// Noncompliant: `ExpectedBucketOwner` or `ExpectedSourceBucketOwner` argument is missing.
+	_, err = s3Client.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+		Body:   file,
+	})
+	if err != nil {
+		log.Printf("Couldn't upload file %v to %v:%v. Error: %v\n", fileName, bucketName, objectKey, err)
+	}
+}
+
+// {/fact}
+
+// {fact rule=s3-verify-bucket-owner@v1.0 defects=0}
+func s3VerifyBucketOwnerCompliant() {
+	fileName := "YOUR_PATH"
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(awsRegion),
+	})
+	if err != nil {
+		log.Fatal("Error:", err)
+		return
+	}
+	s3Client := s3.New(sess)
+	file, err := os.Open(fileName)
+	if err != nil {
+		log.Printf("Couldn't open file %v to upload. Error: %v\n", fileName, err)
+	}
+	defer file.Close()
+	// Compliant: `ExpectedBucketOwner` is present.
+	_, err = s3Client.PutObject(&s3.PutObjectInput{
+		Bucket:              aws.String(bucketName),
+		Key:                 aws.String(objectKey),
+		Body:                file,
+		ExpectedBucketOwner: aws.String(expectedBucketOwner),
+	})
+	if err != nil {
+		log.Printf("Couldn't upload file %v to %v:%v. Error: %v\n", fileName, bucketName, objectKey, err)
+	}
+}
+
+// {/fact}

--- a/go_filtered_100/SQLfp.go
+++ b/go_filtered_100/SQLfp.go
@@ -1,0 +1,47 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"database/sql"
+	"net/http"
+)
+
+var (
+	db *sql.DB
+)
+// {fact rule=sql-injection@v1.0 defects=1}
+func executeQuery(query string) {
+	db.Query(query)
+}
+// {/fact}
+func formatQuery(field string, table string, user string) string {
+	return "SELECT " + field + " FROM " + table + " WHERE username=" + user
+}
+
+func HTTPHandler(w http.ResponseWriter, r *http.Request) {
+	FIELD := "name"
+	TABLE := "users"
+
+	response := r.URL.Query()["users"]
+	user := response[0]
+
+	executeQuery(formatQuery(FIELD, TABLE, user))
+}
+
+func main2() {
+	http.HandleFunc("/", HTTPHandler)
+	http.ListenAndServe(":8080", nil)
+}

--- a/go_filtered_100/SshEmptyPassword.go
+++ b/go_filtered_100/SshEmptyPassword.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+    "log"
+    "os"
+
+    "golang.org/x/crypto/ssh"
+    "golang.org/x/crypto/ssh/knownhosts"
+)
+
+// {fact rule=improper-authentication@v1.0 defects=1}
+func sshEmptyPasswordNoncompliant() {
+    // ssh config
+    customHostKeyCallback, err := knownhosts.New("/home/username/.ssh/known_hosts")
+    if err != nil {
+        log.Fatal("Error initializing host key callback:", err)
+    }
+    sshConfig := &ssh.ClientConfig{
+        User: "exampleuser",
+        Auth: []ssh.AuthMethod{
+            // Noncompliant: Empty password in ssh config.
+            ssh.Password(""),
+        },
+        HostKeyCallback: customHostKeyCallback,
+    }
+
+    _, err = ssh.Dial("tcp", "192.168.1.100:22", sshConfig)
+    if err != nil {
+        log.Fatal("Failed to dial: ", err)
+    }
+}
+// {/fact}
+
+// {fact rule=improper-authentication@v1.0 defects=0}
+func sshEmptyPasswordCompliant() {
+    customHostKeyCallback, err := knownhosts.New("/home/username/.ssh/known_hosts")
+    if err != nil {
+         log.Fatal("Error initializing host key callback:", err)
+    }
+    sshConfig := &ssh.ClientConfig{
+        User: "exampleuser",
+        Auth: []ssh.AuthMethod{
+            // Compliant: Password is fetched from environment variable.
+            ssh.Password(os.Getenv("PASSWORD")),
+        },
+        HostKeyCallback: customHostKeyCallback,
+    }
+
+    _, err = ssh.Dial("tcp", "192.168.1.100:22", sshConfig)
+    if err != nil {
+        log.Fatal("Failed to dial: ", err)
+    }
+}
+// {/fact}

--- a/go_filtered_100/TemporaryFiles.go
+++ b/go_filtered_100/TemporaryFiles.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// {fact rule=insecure-temp-file@v1.0 defects=1}
+func temporaryFilesNoncompliant() {
+	// Noncompliant: File creation in shared tmp directory without using `os.CreateTemp`.
+	file, err := os.Create("/tmp/file")
+	if err != nil {
+		fmt.Println("Error occurred during file creation")
+	}
+	defer file.Close()
+}
+
+// {/fact}
+
+// {fact rule=insecure-temp-file@v1.0 defects=0}
+func temporaryFilesCompliant() {
+	// Compliant : File creation in shared tmp directory with using `os.CreateTemp`.
+	file, err := os.CreateTemp("/tmp", "file")
+	if err != nil {
+		fmt.Println("Error occurred during file creation")
+	}
+	defer file.Close()
+}
+
+// {/fact}

--- a/go_filtered_100/ThreadSafetyViolation.go
+++ b/go_filtered_100/ThreadSafetyViolation.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"sync"
+)
+
+// {fact rule=thread-safety-violation@v1.0 defects=1}
+func threadSafetyViolationNoncompliant(){
+    var counter int
+    var wg sync.WaitGroup
+
+    for i:=0; i < 1000; i++{
+        wg.Add(1)
+        go func() {
+            // Noncompliant: incrementing without synchronization.
+            counter ++
+            wg.Done()
+        }()
+    }
+    wg.Wait()
+}
+// {/fact}
+
+// {fact rule=thread-safety-violation@v1.0 defects=0}
+func threadSafetyViolationCompliant(){
+    var counter int
+    var wg sync.WaitGroup
+    var mu sync.Mutex
+    for i:=0; i < 1000; i++{
+        wg.Add(1)
+        go func() {
+            mu.Lock()
+            // Compliant: `sync.Mutex` is used to ensure only one goroutine can modify shared data at a time.
+            counter ++
+            mu.Unlock()
+            wg.Done()
+        }()
+    }
+    wg.Wait()
+}
+// {/fact}

--- a/go_filtered_100/UnsafeReflection.go
+++ b/go_filtered_100/UnsafeReflection.go
@@ -1,0 +1,56 @@
+package testing
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// {fact rule=unsafe-reflection@v1.0 defects=1}
+func unsafeReflectionNoncompliant(jobInstance interface{}, userInput string) map[string]interface{} {
+	data := make(map[string]interface{})
+
+	jobValue := reflect.ValueOf(jobInstance).Elem()
+
+	// Noncompliant: unsafe user input passed.
+	method := jobValue.MethodByName(userInput)
+
+	if method.IsValid() {
+		colorValue := method.Call(nil)[0].Interface()
+		data["color"] = fmt.Sprintf("%v", colorValue)
+	} else {
+		colorField := jobValue.FieldByName("color")
+		if colorField.IsValid() && colorField.Kind() == reflect.String {
+			data["color"] = colorField.String()
+		} else {
+			data["color"] = "unknown"
+		}
+	}
+	return data
+}
+
+// {/fact}
+
+// {fact rule=unsafe-reflection@v1.0 defects=0}
+func unsafeReflectionCompliant(jobInstance interface{}) map[string]interface{} {
+	data := make(map[string]interface{})
+
+	jobValue := reflect.ValueOf(jobInstance).Elem()
+
+	// Compliant: Constant input passed.
+	method := jobValue.MethodByName("name")
+
+	if method.IsValid() {
+		colorValue := method.Call(nil)[0].Interface()
+		data["color"] = fmt.Sprintf("%v", colorValue)
+	} else {
+		colorField := jobValue.FieldByName("color")
+		if colorField.IsValid() && colorField.Kind() == reflect.String {
+			data["color"] = colorField.String()
+		} else {
+			data["color"] = "unknown"
+		}
+	}
+	return data
+}
+
+// {/fact}

--- a/go_filtered_100/UseFilepathJoin.go
+++ b/go_filtered_100/UseFilepathJoin.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+)
+
+// {fact rule=best-practices@v1.0 defects=1}
+func useFilepathJoinNoncompliant() {
+	pathname := "YOUR_PATH"
+	// Noncompliant: Uses `path.Join()` instead of `filepath.Join()`.
+	fmt.Println(path.Join(path.Base(pathname), "baz"))
+}
+
+// {/fact}
+
+// {fact rule=best-practices@v1.0 defects=0}
+func useFilepathJoinCompliant() {
+	pathname := "YOUR_PATH"
+	// Compliant: Uses `filepath.join()`.
+	fmt.Println(filepath.Join(path.Base(pathname), "baz"))
+}
+
+// {/fact}

--- a/go_filtered_100/UselessIfBody.go
+++ b/go_filtered_100/UselessIfBody.go
@@ -1,0 +1,25 @@
+package main
+
+import "fmt"
+
+// {fact rule=best-practices@v1.0 defects=1}
+func uselessIfBodyNoncompliant(num int){
+	// Noncompliant: Both `if` and `else` have same body.
+	if num == 3 {
+		fmt.Println("Hello")
+	} else {
+		fmt.Println("Hello")
+	}
+}
+// {/fact}
+
+// {fact rule=best-practices@v1.0 defects=0}
+func uselessIfBodyCompliant(num int){
+	// Compliant: `if` and `else` have different body.
+	if num == 3 {
+		fmt.Println("Hello")
+	} else {
+	    fmt.Println("Bye")
+	}
+}
+// {/fact}

--- a/go_filtered_100/XmlExternalEntity.go
+++ b/go_filtered_100/XmlExternalEntity.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"github.com/lestrrat-go/libxml2/parser"
+)
+
+// {fact rule=xml-external-entity@v1.0 defects=1}
+func xmlExternalEntityNoncompliant() {
+	const xmlData = "<!DOCTYPE d [<!ENTITY e SYSTEM \"file:///etc/passwd\">]><t>&e;</t>"
+	// Noncompliant: `XMLParseNoEnt` is enabled.
+	xmlParser := parser.New(parser.XMLParseNoEnt)
+	parsedDoc, err := xmlParser.ParseString(xmlData)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("XML document successfully parsed!")
+	fmt.Println(parsedDoc)
+}
+// {/fact}
+
+// {fact rule=xml-external-entity@v1.0 defects=0}
+func xmlExternalEntityCompliant() {
+	const xmlData = "<!DOCTYPE d [<!ENTITY e SYSTEM \"file:///etc/passwd\">]><t>&e;</t>"
+	// Compliant: `XMLParseNoEnt` is not enabled.
+	xmlParser := parser.New()
+	parsedDoc, err := xmlParser.ParseString(xmlData)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("XML document successfully parsed!")
+	fmt.Println(parsedDoc)
+}
+// {/fact}

--- a/go_filtered_100/cmdi.go
+++ b/go_filtered_100/cmdi.go
@@ -1,0 +1,89 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"github.com/praetorian-inc/gokart/util"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+)
+
+// CommandInjectionAnalyzer constructs Sinks from a set of functions known to be vulnerable to command injection,
+// converts all variables to SSA form to construct a call graph and performs
+// recursive taint analysis to search for input sources of user-controllable data
+var CommandInjectionAnalyzer = &analysis.Analyzer{
+	Name:     "command_injection",
+	Doc:      "reports when command injection can occur",
+	Run:      cmdInjectionRun,
+	Requires: []*analysis.Analyzer{buildssa.Analyzer},
+}
+
+// vulnCmdInjectionFuncs() returns a map of command injection functions that may be vulnerable when used with user controlled input
+func vulnCmdInjectionFuncs() map[string][]string {
+	return map[string][]string{
+		"os/exec":                   {"Command", "CommandContext"},
+		"syscall":                   {"Exec", "ForkExec", "StartProcess"},
+		"golang.org/x/sys/execabs/": {"Command", "CommandContext"},
+	}
+}
+
+// command_injection_run runs the command injection analyzer
+func cmdInjectionRun(pass *analysis.Pass) (interface{}, error) {
+	results := []util.Finding{}
+
+	// Builds SSA model of Go code
+	ssaFuncs := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
+
+	// Creates call graph of function calls
+	call_graph := make(util.CallGraph)
+
+	// Fills in call graph
+	for _, fn := range ssaFuncs {
+		call_graph.AnalyzeFunction(fn)
+	}
+
+	// Grabs vulnerable functions to scan for
+	vulnPathFuncs := vulnCmdInjectionFuncs()
+
+	// Iterate over every specified vulnerable package
+	for pkg, funcs := range vulnPathFuncs {
+
+		// Iterate over every specified vulnerable function per package
+		for _, fn := range funcs {
+
+			// Construct full name of function
+			current_function := pkg + "." + fn
+
+			// Iterate over occurrences of vulnerable function in call graph
+			for _, vulnFunc := range call_graph[current_function] {
+
+				// Check if argument of vulnerable function is tainted by possibly user-controlled input
+				taintAnalyzer := util.CreateTaintAnalyzer(pass, vulnFunc.Fn.Pos())
+				for i := 0; i < len(vulnFunc.Instr.Call.Args); i++ {
+					if taintAnalyzer.ContainsTaint(&vulnFunc.Instr.Call, &vulnFunc.Instr.Call.Args[i], call_graph) {
+						message := "Danger: possible command injection detected"
+						targetFunc := util.GenerateTaintedCode(pass, vulnFunc.Fn, vulnFunc.Instr.Pos())
+						taintSource := taintAnalyzer.TaintSource
+						finding := util.MakeFinding(message, targetFunc, taintSource, "CWE-78: OS Command Injection")
+						results = append(results, finding)
+					}
+				}
+			}
+		}
+	}
+
+	return results, nil
+}

--- a/go_filtered_100/cmdi_case.go
+++ b/go_filtered_100/cmdi_case.go
@@ -1,0 +1,45 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/gokart/test/testutil"
+)
+
+func TestCommandInjection(t *testing.T) {
+	testFiles := []string{
+		"command_context_injection_safe.go",
+		"command_injection.go",
+		"commandContext.go",
+	}
+
+	// Append directory to each entry
+	for i := 0; i < len(testFiles); i++ {
+		testFiles[i] = "command_injection/" + testFiles[i]
+	}
+
+	testResults := []int{
+		0,
+		2,
+		2,
+	}
+	for i := 0; i < len(testFiles); i++ {
+		t.Run(testFiles[i], func(t *testing.T) {
+			testutil.RunTest(testFiles[i], testResults[i], "CWE-78: OS Command Injection", CommandInjectionAnalyzer, t)
+		})
+	}
+}

--- a/go_filtered_100/commandContext.go
+++ b/go_filtered_100/commandContext.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func main8() {
+// {fact rule=os-command-injection@v1.0 defects=1}
+	reader1 := bufio.NewReader(os.Stdin)
+	reader2 := bufio.NewReader(os.Stdin)
+
+	text1, _ := reader1.ReadString('\n')
+	text2, _ := reader2.ReadString('\n')
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	if err := exec.CommandContext(ctx, text1, text2).Run(); err != nil {
+		// This will fail after 100 milliseconds. The 5 second sleep
+		// will be interrupted.
+	}
+// {/fact}
+}

--- a/go_filtered_100/command_context_injection_safe.go
+++ b/go_filtered_100/command_context_injection_safe.go
@@ -1,0 +1,49 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+func main() {
+// {fact rule=os-command-injection@v1.0 defects=0}
+	// Create a new context and add a timeout to it
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel() // The cancel should be deferred so resources are cleaned up
+
+	// Create the command with our context
+	cmd := exec.CommandContext(ctx, "ping", "-c 4", "-i 1", "8.8.8.8")
+
+	// This time we can simply use Output() to get the result.
+	out, err := cmd.Output()
+// {/fact}
+	// We want to check the context error to see if the timeout was executed.
+	// The error returned by cmd.Output() will be OS specific based on what
+	// happens when a process is killed.
+	if ctx.Err() == context.DeadlineExceeded {
+		fmt.Println("Command timed out")
+		return
+	}
+
+	// If there's no context error, we know the command completed (or errored).
+	fmt.Println("Output:", string(out))
+	if err != nil {
+		fmt.Println("Non-zero exit code:", err)
+	}
+}

--- a/go_filtered_100/command_injection.go
+++ b/go_filtered_100/command_injection.go
@@ -1,0 +1,70 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// 2 vulnerabilities should be reported, on lines 28, 34
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func get_user_input() string {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("Enter command: ")
+	text, _ := reader.ReadString('\n')
+	return text
+}
+
+func constant_func() string {
+	return "test1" + "test2"
+}
+// {fact rule=os-command-injection@v1.0 defects=0}
+func no_command_injection() {
+	msg := "This echo is safe."
+	cmd := exec.Command("echo", msg, "Yes it is.")
+	cmd.Run()
+}
+// {/fact}
+
+// {fact rule=os-command-injection@v1.0 defects=1}
+func command_injection_user_input() {
+	text := get_user_input()
+	cmd := exec.Command("sh", "echo", "hi", "&&", text)
+	cmd.Run()
+}
+// {/fact}
+// {fact rule=os-command-injection@v1.0 defects=1}
+func command_injection_firstarg() {
+	msg := get_user_input()
+	cmd := exec.Command(msg, "echo", "hi")
+	cmd.Run()
+}
+// {/fact}
+// {fact rule=os-command-injection@v1.0 defects=0}
+func no_command_injection_function() {
+	msg := constant_func()
+	cmd := exec.Command("sh", "echo", "hi", "&&", msg)
+	cmd.Run()
+}
+// {/fact}
+
+func command_injection_main() {
+	no_command_injection()
+	command_injection_user_input()
+	command_injection_firstarg()
+	no_command_injection_function()
+}

--- a/go_filtered_100/config.go
+++ b/go_filtered_100/config.go
@@ -1,0 +1,188 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	_ "embed"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigType stores booleans for GoKart analysis configuration
+type ConfigType struct {
+	GlobalsSafe bool
+	OutputSarif bool
+	OutputJSON  bool
+	Debug       bool
+	Verbose     bool
+	ExitCode    bool
+	YMLPath     string
+	OutputPath  string
+}
+
+// ConfigFile stores the values parsed from the configuration file
+type ConfigFile struct {
+	Analyzers map[string]Analyzer `yaml:"analyzers"`
+	Sources   Sources             `yaml:"sources"`
+}
+
+// Analyzer stores an analyzer parsed from the configuration file
+type Analyzer struct {
+	Doc       string              `yaml:"doc"`
+	Message   string              `yaml:"message"`
+	VulnCalls map[string][]string `yaml:"vuln_calls"`
+}
+
+// Sources stores the untrusted sources parsed from the configuration file
+type Sources struct {
+	Variables map[string][]string `yaml:"variables"`
+	Functions map[string][]string `yaml:"functions"`
+	Types     map[string][]string `yaml:"types"`
+	// For compatibility with older analyzer.yml format
+	OldSrcs *Sources `yaml:"sources"`
+}
+
+var (
+	FilesFound      = 0
+	VulnGlobalVars  map[string][]string
+	VulnGlobalFuncs map[string][]string
+	VulnTypes       map[string][]string
+	//go:embed analyzers.yml
+	DefaultAnalyzersContent []byte
+)
+
+var (
+	configDir string
+	once      sync.Once
+)
+
+var (
+	Config     ConfigType
+	ScanConfig ConfigFile
+)
+
+func LoadScanConfig() {
+	configBytes, err := ioutil.ReadFile(Config.YMLPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := yaml.Unmarshal(configBytes, &ScanConfig); err != nil {
+		log.Fatal(err)
+	}
+
+	// If OldSrcs isn't nil, then the config file is in the old format and we unnest the values
+	if ScanConfig.Sources.OldSrcs != nil {
+		ScanConfig.Sources.Functions = ScanConfig.Sources.OldSrcs.Functions
+		ScanConfig.Sources.Variables = ScanConfig.Sources.OldSrcs.Variables
+		ScanConfig.Sources.Types = ScanConfig.Sources.OldSrcs.Types
+		// Set OldSrcs to nil to let the garbage collector clean it up
+		ScanConfig.Sources.OldSrcs = nil
+	}
+
+	if Config.Debug {
+		log.Println("Beginning list of default sources defined in yml:")
+		for pkg, fn := range ScanConfig.Sources.Functions {
+			log.Printf("Functions %s in package %s\n", fn, pkg)
+		}
+
+		if len(ScanConfig.Analyzers) > 0 {
+			log.Println("\nBeginning list of analyzers defined in yml:")
+			for name, values := range ScanConfig.Analyzers {
+				log.Printf("Name:    %s\n", name)
+				log.Printf("Doc:     %s\n", values.Doc)
+				log.Printf("Message: %s\n", values.Message)
+				log.Println("Vuln Calls:")
+				for pkg, fn := range values.VulnCalls {
+					log.Printf("Functions %s in package %s\n", fn, pkg)
+				}
+			}
+		}
+		log.Printf("\n\n")
+	}
+	VulnGlobalVars = ScanConfig.Sources.Variables
+	VulnGlobalFuncs = ScanConfig.Sources.Functions
+	VulnTypes = ScanConfig.Sources.Types
+}
+
+// InitConfig() parses the flags and sets the corresponding Config variables
+func InitConfig(globals bool, sarif bool, json bool, verbose bool, debug bool, output_path string, yml string, exitCode bool) {
+	if yml == "" {
+		yml = getDefaultConfigPath()
+	} else if _, err := os.Stat(yml); err != nil {
+		log.Fatalf("failed to find the provided config file at %s: %v", yml, err)
+	}
+	if !(json || sarif) {
+		fmt.Printf("Using config found at %s\n", yml)
+	}
+
+	Config.GlobalsSafe = !globals
+	Config.OutputSarif = sarif
+	Config.OutputJSON = json
+	Config.Debug = debug
+	Config.Verbose = verbose
+	Config.ExitCode = exitCode
+	Config.OutputPath = ""
+	// get the absolute path of the output file to avoid issues when changing working directory for loading packages
+	if output_path != "" {
+		abs_output_path, err := filepath.Abs(output_path)
+		if err != nil {
+			log.Fatal(err)
+		}
+		Config.OutputPath = abs_output_path
+	}
+	Config.YMLPath = yml
+	LoadScanConfig()
+}
+// {fact rule=insecure-file-permissions@v1.0 defects=1}
+// getDefaultConfigPath gets the path to the default configuration file and creates it if it doesn't yet exist.
+func getDefaultConfigPath() string {
+	setConfigDir()
+	yamlPath := filepath.Join(configDir, "analyzers.yml")
+
+	// If ~/.gokart/analyzers.yml doesn't exist, create it with the default config
+	if _, err := os.Stat(yamlPath); os.IsNotExist(err) {
+		fmt.Printf("Initializing default config at %s\n", yamlPath)
+		if err := ioutil.WriteFile(yamlPath, DefaultAnalyzersContent, 0o744); err != nil {
+			log.Fatalf("failed to write default config to %s: %v", yamlPath, err)
+		}
+	} else if err != nil {
+		// If the error returned by os.Stat is not ErrNotExist
+		log.Fatalf("failed to initialize default config: %v", err)
+	}
+	return yamlPath
+}
+// {/fact}
+
+// {fact rule=insecure-file-permissions@v1.0 defects=1}
+// setConfigDir initializes the configDir variable upon its first invocation, does nothing otherwise.
+func setConfigDir() {
+	once.Do(func() {
+		userHomeDir, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatalf("failed to get home directory: %v", err)
+		}
+		configDir = filepath.Join(userHomeDir, ".gokart")
+		if err = os.MkdirAll(configDir, 0o744); err != nil {
+			log.Fatalf("failed to create config directory %s: %v", configDir, err)
+		}
+	})
+}
+// {/fact}

--- a/go_filtered_100/finding.go
+++ b/go_filtered_100/finding.go
@@ -1,0 +1,154 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// Finding represents a single vulnerability
+type Finding struct {
+	message             string
+	Vulnerable_Function TaintedCode
+	Untrusted_Source    []TaintedCode
+	Type                string
+}
+
+// Create a finding object
+func MakeFinding(message string, vulnerable_function TaintedCode, untrusted_source []TaintedCode, finding_type string) Finding {
+	return Finding{
+		message:             message,
+		Vulnerable_Function: vulnerable_function,
+		Untrusted_Source:    untrusted_source,
+		Type:                finding_type,
+	}
+}
+
+func StripArguments(parentFunction string) string {
+	functionName := strings.Split(parentFunction, "(")[0]
+	functionReturn := ""
+	if splitOnClose := strings.Split(parentFunction, ")"); len(splitOnClose) > 1 {
+		functionReturn = splitOnClose[1]
+	}
+	return strings.TrimSpace(functionName) + "(...)" + functionReturn
+}
+
+// returns true if the finding was valid and false if the finding had the same source and sink
+func IsValidFinding(finding Finding) bool {
+	if len(finding.Untrusted_Source) == 0 {
+		return false
+	}
+	if finding.Vulnerable_Function.SourceCode == finding.Untrusted_Source[0].SourceCode {
+		// if the source and sink are the same, return false and do not print out the finding
+		return false
+	}
+	// add filtering for findings with chan sources
+	if strings.Contains(finding.Untrusted_Source[0].SourceCode, "make(chan") {
+		if Config.Debug {
+			log.Printf("Filtering Finding for Source: %s\n", finding.Untrusted_Source[0].SourceCode)
+		}
+		return false
+	}
+	return true
+}
+
+func OutputFindingMetadata(results []Finding, outputColor bool) {
+	var ok bool
+	findingCounts := make(map[string]int)
+
+	for _, finding := range results {
+		_, ok = findingCounts[finding.Type]
+		if ok {
+			findingCounts[finding.Type] += 1
+		} else {
+			findingCounts[finding.Type] = 1
+		}
+	}
+
+	for findingType, count := range findingCounts {
+		if outputColor {
+			yellow := color.New(color.FgYellow).SprintFunc()
+			cyan := color.New(color.FgCyan).SprintFunc()
+			fmt.Printf("Identified %s potential %s\n", yellow(count), cyan(findingType))
+		} else {
+			fmt.Printf("Identified %d potential %s\n", count, findingType)
+		}
+	}
+}
+
+// prints out a finding
+func OutputFinding(finding Finding, outputColor bool) {
+	if Config.OutputSarif {
+		SarifRecordFinding(finding.Type, finding.message, finding.Vulnerable_Function.SourceFilename,
+			finding.Vulnerable_Function.SourceLineNum)
+	} else if Config.OutputJSON {
+		// the JSON output is printed in OutputResults in scan.go, so nothing to do for this finding
+		return
+	} else {
+		yellow := color.New(color.FgYellow).SprintFunc()
+		cyan := color.New(color.FgCyan).SprintFunc()
+		green := color.New(color.FgGreen).SprintFunc()
+		red := color.New(color.FgRed).SprintFunc()
+
+		sinkParentNoArgs := StripArguments(finding.Vulnerable_Function.ParentFunction)
+
+		if outputColor {
+			fmt.Printf("\n(%s) %s\n\n", cyan(finding.Type), yellow(finding.message))
+		} else {
+			fmt.Printf("\n(%s) %s\n\n", finding.Type, finding.message)
+		}
+		fmt.Printf("%s:%d\nVulnerable Function: [ %s ]\n", finding.Vulnerable_Function.SourceFilename, finding.Vulnerable_Function.SourceLineNum, sinkParentNoArgs)
+		fmt.Printf("      %d:\t%s\n", finding.Vulnerable_Function.SourceLineNum-1, GrabSourceCode(finding.Vulnerable_Function.SourceFilename, finding.Vulnerable_Function.SourceLineNum-1))
+		if outputColor {
+			fmt.Printf("    > %d:\t%s\n", finding.Vulnerable_Function.SourceLineNum, red(finding.Vulnerable_Function.SourceCode))
+		} else {
+			fmt.Printf("    > %d:\t%s\n", finding.Vulnerable_Function.SourceLineNum, finding.Vulnerable_Function.SourceCode)
+		}
+		fmt.Printf("      %d:\t%s\n", finding.Vulnerable_Function.SourceLineNum+1, GrabSourceCode(finding.Vulnerable_Function.SourceFilename, finding.Vulnerable_Function.SourceLineNum+1))
+
+		if finding.Untrusted_Source != nil {
+
+			source := finding.Untrusted_Source[0]
+			fmt.Printf("\n%s:%d\n", source.SourceFilename, source.SourceLineNum)
+			fmt.Printf("Source of Untrusted Input: [ %s ]\n", StripArguments(source.ParentFunction))
+			fmt.Printf("      %d:\t%s\n", source.SourceLineNum-1, GrabSourceCode(source.SourceFilename, source.SourceLineNum-1))
+			if outputColor {
+				fmt.Printf("    > %d:\t%s\n", source.SourceLineNum, red(source.SourceCode))
+			} else {
+				fmt.Printf("    > %d:\t%s\n", source.SourceLineNum, source.SourceCode)
+			}
+			fmt.Printf("      %d:\t%s\n", source.SourceLineNum+1, GrabSourceCode(source.SourceFilename, source.SourceLineNum+1))
+
+			if Config.Verbose {
+				if outputColor {
+					fmt.Print(green("\n############################### FULL TRACE ###############################\n"))
+				} else {
+					fmt.Print("\n############################### FULL TRACE ###############################\n")
+				}
+				fmt.Printf("\nUntrusted Input Source:")
+				for _, source := range finding.Untrusted_Source {
+					fmt.Printf("%s:%d:\n[ %s ]\n>>>\t%s\n", source.SourceFilename,
+						source.SourceLineNum, StripArguments(source.ParentFunction), strings.TrimLeft(source.SourceCode, " \t"))
+				}
+			}
+
+		}
+		fmt.Printf("------------------------------------------------------------------------------\n")
+	}
+}

--- a/go_filtered_100/generic.go
+++ b/go_filtered_100/generic.go
@@ -1,0 +1,83 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"github.com/praetorian-inc/gokart/util"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+)
+
+// Creates generic taint analyzer based on Sources and Sinks defined in analyzers.yaml file
+func genericFunctionRun(pass *analysis.Pass, vulnPathFuncs map[string][]string,
+	name string, message string) (interface{}, error) {
+	results := []util.Finding{}
+
+	// Build SSA model of Go code
+	ssaFuncs := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
+
+	// Create call graph of function calls
+	cg := make(util.CallGraph)
+
+	// Fill in call graph
+	for _, fn := range ssaFuncs {
+		cg.AnalyzeFunction(fn)
+	}
+
+	// Iterate over every specified vulnerable package
+	for pkg, funcs := range vulnPathFuncs {
+		// Iterate over every specified vulnerable function per package
+		for _, fn := range funcs {
+			// Construct full name of function
+			currentFunc := pkg + "." + fn
+			// Iterate over occurrences of vulnerable function in call graph
+			for _, vulnFunc := range cg[currentFunc] {
+				// Check if argument of vulnerable function is tainted by possibly user-controlled input
+				taintAnalyzer := util.CreateTaintAnalyzer(pass, vulnFunc.Fn.Pos())
+				for i := 0; i < len(vulnFunc.Instr.Call.Args); i++ {
+					if taintAnalyzer.ContainsTaint(&vulnFunc.Instr.Call, &vulnFunc.Instr.Call.Args[i], cg) {
+						targetFunc := util.GenerateTaintedCode(pass, vulnFunc.Fn, vulnFunc.Instr.Pos())
+						taintSource := taintAnalyzer.TaintSource
+						results = append(results, util.MakeFinding(message, targetFunc, taintSource, name))
+					}
+				}
+			}
+		}
+	}
+	return results, nil
+}
+
+// LoadGenericAnalyzers creates generic taint analyzers from custom Sources and Sinks defined in analyzers.yaml
+// converts all variables to SSA form to construct a call graph and performs
+// recursive taint analysis to search for input sources of user-controllable data
+func LoadGenericAnalyzers() []*analysis.Analyzer {
+	var analyzers []*analysis.Analyzer
+
+	for analyzerName, analyzerDict := range util.ScanConfig.Analyzers {
+		vulnCalls, analyzerName, message := analyzerDict.VulnCalls, analyzerName, analyzerDict.Message
+		analyzerFunc := func(pass *analysis.Pass) (interface{}, error) {
+			return genericFunctionRun(pass, vulnCalls, analyzerName, message)
+		}
+		analysisRun := analysis.Analyzer{
+			Name:     analyzerName,
+			Doc:      analyzerDict.Doc,
+			Run:      analyzerFunc,
+			Requires: []*analysis.Analyzer{buildssa.Analyzer},
+		}
+		analyzers = append(analyzers, &analysisRun)
+	}
+
+	return analyzers
+}

--- a/go_filtered_100/gosecFalsePositive1.go
+++ b/go_filtered_100/gosecFalsePositive1.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+import (
+	"net/http"
+	"os"
+)
+// {fact rule=insecure-connection@v1.0 defects=1}
+func gosecFalsePositive1Main() {
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}
+// {/fact}
+
+// {fact rule=path-traversal@v1.0 defects=1}
+func handler(w http.ResponseWriter, r *http.Request) {
+
+	keys := r.URL.Query()["key"]
+	user_input := keys[0]
+
+	os.Open(temp8(user_input))
+}
+// {/fact}
+func temp8(str string) string {
+	return str
+}

--- a/go_filtered_100/gosecFalsePositive2.go
+++ b/go_filtered_100/gosecFalsePositive2.go
@@ -1,0 +1,30 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+func rsaGenerator() {
+	key_length := 100
+	rsaHelper(key_length)
+}
+// {fact rule=cryptographic-key-generator@v1.0 defects=0}
+func rsaHelper(length int) {
+	rsa.GenerateKey(rand.Reader, length)
+}
+// {/fact}

--- a/go_filtered_100/main.go
+++ b/go_filtered_100/main.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+
+GoKart is a scanner for go applications
+
+Run it in the go module directory of the module you want to scan with gokart scan
+
+GoKart is split up into a series of analyzers that each look for a specific vulnerability class. These are contained in
+the `gokart/analyzers` package.
+
+GoKart uses SSA to track the sources of data, to perform taint analysis. This means that GoKart can track how data flows
+through an application, to remove false positives from data that comes from a trusted source
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/praetorian-inc/gokart/cmd"
+)
+
+func main() {
+	err := cmd.Execute()
+	if err != nil {
+		fmt.Printf("\nError: %s\n\nTry \"gokart help\" to steer GoKart in the right direction.\n\n", err)
+		os.Exit(1)
+	}
+}

--- a/go_filtered_100/module.go
+++ b/go_filtered_100/module.go
@@ -1,0 +1,73 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"log"
+	"os"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+)
+
+// CloneModule clones a remote git repository
+// An optional keyfile may be specified for use in ssh authentication
+// If quiet is true, don't print clone progress to stdout
+func CloneModule(dir string, url string, branch string, keyFile string, quiet bool) error {
+	var cloneOptions git.CloneOptions
+
+	cloneOptions = git.CloneOptions{
+		URL: url,
+	}
+// {fact rule=log-injection@v1.0 defects=0}
+	if !quiet {
+		log.Printf("Cloning new remote module: %s\n", url)
+		cloneOptions.Progress = os.Stdout
+	}
+// {/fact}
+
+// {fact rule=log-injection@v1.0 defects=0}
+	if len(branch) != 0 {
+		log.Printf("Cloning with remote branch reference: %s\n", branch)
+		cloneOptions.ReferenceName = plumbing.NewBranchReferenceName(branch)
+	}
+// {/fact}
+	if len(keyFile) != 0 {
+		_, err := os.Stat(keyFile)
+		if err != nil {
+			log.Printf("Read file %s failed %s\n", keyFile, err.Error())
+			return err
+		}
+// {fact rule=log-injection@v1.0 defects=0}
+		// Clone the given repository to the given directory (password set to "")
+		publicKeys, err := ssh.NewPublicKeysFromFile("git", keyFile, "")
+		if err != nil {
+			log.Printf("Generate publickeys from file %s failed: %s\n", keyFile, err.Error())
+			return err
+		}
+		log.Printf("Authenticating with ssh keyfile: %s\n", keyFile)
+		cloneOptions.Auth = publicKeys
+	}
+// {/fact}
+	_, err := git.PlainClone(dir, false, &cloneOptions)
+	return err
+}
+
+//CleanupModule attempts to delete a directory.
+func CleanupModule(dir string) error {
+	err := os.RemoveAll(dir)
+	return err
+}

--- a/go_filtered_100/path1.go
+++ b/go_filtered_100/path1.go
@@ -1,0 +1,55 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+// Expect 7 vulnerabilities found
+
+import (
+	"bufio"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+)
+func DirTraversal1(filename string, folderPath string) {
+	// {fact rule=path-traversal@v1.0 defects=1}
+	os.Create(folderPath + filename)
+	// {/fact}
+	// {fact rule=path-traversal@v1.0 defects=1}
+	os.Open(folderPath + filename)
+	// {/fact}
+	// {fact rule=path-traversal@v1.0 defects=1}
+	os.OpenFile(folderPath+filename, os.O_RDONLY, 0775)
+	// {/fact}
+	// {fact rule=path-traversal@v1.0 defects=1}
+	ioutil.ReadFile(folderPath + filename)
+	// {/fact}
+	// {fact rule=path-traversal@v1.0 defects=1}
+	ioutil.WriteFile(folderPath+filename, []byte("Hello, Gophers!"), 0775)
+	// {/fact}
+	// {fact rule=path-traversal@v1.0 defects=1}
+	path.Join(folderPath, filename)
+	// {/fact}
+	// {fact rule=path-traversal@v1.0 defects=1}
+	filepath.Join(folderPath, filename)
+	// {/fact}
+}
+
+func tempTest() {
+	reader := bufio.NewReader(os.Stdin)
+	hiddenMessage, _ := reader.ReadString('\n')
+	hiddenMessage2 := "hidden2"
+	DirTraversal1(hiddenMessage, hiddenMessage2)
+}

--- a/go_filtered_100/path2.go
+++ b/go_filtered_100/path2.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+import (
+	"bufio"
+	"os"
+)
+// {fact rule=path-traversal@v1.0 defects=1}
+func getVuln() string {
+	reader := bufio.NewReader(os.Stdin)
+	hiddenMessage, _ := reader.ReadString('\n')
+	return hiddenMessage
+}
+
+func DirTraversal2(filename string) string {
+	folderPath := "./list1/images/"
+	// f, _ := os.Create(folderPath + filename + getVuln())
+	f, _ := os.Create(folderPath + getVuln())
+	f.Close()
+	return folderPath
+}
+// {/fact}

--- a/go_filtered_100/path3.go
+++ b/go_filtered_100/path3.go
@@ -1,0 +1,30 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+import (
+	"os"
+)
+
+func getFile1() string {
+	return "hacked"
+}
+// {fact rule=path-traversal@v1.0 defects=0}
+func DirTraversal3() {
+	folderPath := "./list1/images/"
+	f, _ := os.Create(folderPath + getFile1())
+	f.Close()
+}
+// {/fact}

--- a/go_filtered_100/path4.go
+++ b/go_filtered_100/path4.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+import (
+	"os"
+)
+
+func getFile2(temp string) string {
+	return temp
+}
+// {fact rule=path-traversal@v1.0 defects=0}
+func DirTraversal4() {
+	safe := "hello"
+	folderPath := "./list1/images/"
+	f, _ := os.Create(folderPath + getFile2(safe))
+	f.Close()
+}
+// {/fact}

--- a/go_filtered_100/pathBin.go
+++ b/go_filtered_100/pathBin.go
@@ -1,0 +1,32 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+// zero vulns should be reported
+import (
+	"os"
+)
+// {fact rule=path-traversal@v1.0 defects=0}
+func getFile3(temp string) string {
+	tmp := "./list1/images/"
+	DirTraversal5(tmp)
+	return "str"
+}
+
+func DirTraversal5(folderPath string) {
+	f, _ := os.Create(folderPath + "test")
+	f.Close()
+}
+// {/fact}

--- a/go_filtered_100/pathBinPhi.go
+++ b/go_filtered_100/pathBinPhi.go
@@ -1,0 +1,38 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+// zero vulns should be reported
+
+import (
+	"os"
+)
+// {fact rule=path-traversal@v1.0 defects=0}
+
+func getFile4(temp string) string {
+	tmp := "./list1/images/"
+	x := 5
+	if x != 5 {
+		tmp = "./etc/passwd"
+	}
+	DirTraversal6(tmp)
+	return "str"
+}
+
+func DirTraversal6(folderPath string) {
+	f, _ := os.Create(folderPath)
+	f.Close()
+}
+// {/fact}

--- a/go_filtered_100/pathMultParams.go
+++ b/go_filtered_100/pathMultParams.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+// zero vulns should be reported
+
+import (
+	"os"
+)
+// {fact rule=path-traversal@v1.0 defects=0}
+func getFile6(temp string) string {
+	tmp := "./list1/images/"
+	DirTraversal8(tmp, "test")
+	return "str"
+}
+
+func DirTraversal8(folderPath string, path2 string) {
+	f, _ := os.Create(folderPath + path2 + "so" + "many" + "params!")
+	f.Close()
+}
+// {/fact}

--- a/go_filtered_100/pathPhi.go
+++ b/go_filtered_100/pathPhi.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+// zero vulns should be reported
+
+import (
+	"os"
+)
+// {fact rule=path-traversal@v1.0 defects=0}
+func getFilePhi(temp string) string {
+	return temp
+}
+
+func DirTraversalPhi() {
+	safe := "hello"
+	folderPath := "./list1/images/"
+	f, _ := os.Create(folderPath + getFilePhi(safe))
+	f.Close()
+}
+// {/fact}

--- a/go_filtered_100/pathReg.go
+++ b/go_filtered_100/pathReg.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+// zero vulns should be reported
+
+import (
+	"os"
+)
+// {fact rule=path-traversal@v1.0 defects=0}
+func getFile5(temp string) string {
+	tmp := "./list1/images/"
+	DirTraversal7(tmp)
+	return "str"
+}
+
+func DirTraversal7(folderPath string) {
+	f, _ := os.Create(folderPath)
+	f.Close()
+}
+// {/fact}

--- a/go_filtered_100/root.go
+++ b/go_filtered_100/root.go
@@ -1,0 +1,66 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/lithammer/dedent"
+	"github.com/spf13/cobra"
+)
+
+var (
+	goKartCmd = &cobra.Command{
+		Use:   "gokart scan",
+		Short: "A static analysis security scanner for Go",
+		Long: dedent.Dedent(`
+		╭────────────────────────── GoKart ──────────────────────────╮
+		│                                                            │
+		│   An open-source static analysis security scanner for Go   │
+		│                                                            │
+		│           https://github.com/praetorian-inc/gokart         │
+		│                                                            │
+		╰────────────────────────────────────────────────────────────╯
+		
+		
+		╭────────────────────── Example usage ───────────────────────╮
+		│                                                            │
+		│           	Recursively scan current directory           │
+		│  ──────────────────────────────────────────────────────    │
+		│  $ gokart scan <flags>                                     │
+		│                                                            │
+		│                   Scan specific directory                  │
+		│  ──────────────────────────────────────────────────────    │
+		│  $ gokart scan <directory> <flags>                         │
+		│                                                            │
+		│                     Get info about flags                   │
+		│  ──────────────────────────────────────────────────────    │
+		│  $ gokart scan -h                                          │
+		│                                                            │
+		╰────────────────────────────────────────────────────────────╯
+	
+		Please report any bugs or feature requests by opening a new
+		issue at https://github.com/praetorian-inc/gokart`),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+)
+
+// Execute is a wrapper to call the GoKart root command
+func Execute() error {
+	return goKartCmd.Execute()
+}
+
+func init() {
+	goKartCmd.CompletionOptions.DisableDefaultCmd = true
+}

--- a/go_filtered_100/rsa.go
+++ b/go_filtered_100/rsa.go
@@ -1,0 +1,185 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"fmt"
+	"go/constant"
+	"go/token"
+
+	"github.com/praetorian-inc/gokart/util"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+	"golang.org/x/tools/go/ssa"
+)
+
+// RSAKeyLenAnalyzer is used to resolve constant values used for RSA key generation in order to more accurately
+// detect use of an insecure RSA key length constructed
+// all variables are converted to SSA form and a call graph is constructed
+// recursive analysis is then used to resolve variables used as a key length to a final constant value at the callsite
+var RsaKeylenAnalyzer = &analysis.Analyzer{
+	Name:     "rsa_keylen",
+	Doc:      "reports when rsa keys are too short",
+	Run:      rsaRun,
+	Requires: []*analysis.Analyzer{buildssa.Analyzer},
+}
+
+const RECOMMENDED_KEYLEN = 2048
+
+// vulnerableRsaFuncs() returns a map of functions that generate RSA keys
+func vulnerableRsaFuncs() map[string][]string {
+	return map[string][]string{
+		"crypto/rsa": {"GenerateKey"},
+	}
+}
+
+// EvalConst attempts to take a value, and simplify it down to a single constant
+// it returns a tuple of (the constant, whether or not it successfully simplified)
+func EvalConst(expr ssa.Value, cg util.CallGraph) (*ssa.Const, bool) {
+
+	switch expr := expr.(type) {
+
+	case *ssa.Const:
+		return expr, true
+	case *ssa.BinOp:
+		X, okX := EvalConst(expr.X, cg)
+		Y, okY := EvalConst(expr.Y, cg)
+
+		if okX && okY {
+			return merge(X, Y, expr)
+		}
+	case *ssa.Call:
+		if dest := expr.Common().StaticCallee(); dest != nil {
+			rets := util.ReturnValues(dest)
+			if len(rets) == 1 && len(rets[0]) == 1 {
+				return EvalConst(rets[0][0], cg)
+			}
+		}
+	case *ssa.Parameter:
+		var values []*ssa.Value
+		values = cg.ResolveParam(expr)
+		return EvalConst(*values[0], cg)
+
+	case *ssa.Phi:
+		var res bool
+		var val *ssa.Const
+		val, res = EvalConst(expr.Edges[0], cg)
+
+		for _, edge := range expr.Edges {
+			var tmp *ssa.Const
+			var tmp2 bool
+			tmp, tmp2 = EvalConst(edge, cg)
+			if tmp.Int64() < val.Int64() {
+				val = tmp //val ends up being the shortest value that this phi node could be
+			}
+			res = res && tmp2 //res is whether or not the boolean expr could be evaluated
+		}
+		return val, res
+	}
+
+	return nil, false
+}
+
+// Merge merges two Consts to a BinOp
+func merge(x, y *ssa.Const, op *ssa.BinOp) (*ssa.Const, bool) {
+	switch op.Op {
+	case token.ADD, token.SUB, token.MUL:
+		return ssa.NewConst(constant.BinaryOp(x.Value, op.Op, y.Value), x.Type()), true
+	case token.QUO:
+		return ssa.NewConst(constant.BinaryOp(x.Value, token.QUO_ASSIGN, y.Value), x.Type()), true
+
+	}
+	return nil, false
+}
+
+// keylen_check recursively checks if a vulnerable function that relies on RSA is using a number of bits that is less than RECOMMENDED_KEYLEN
+func keylen_check(pass *analysis.Pass, keylen ssa.Value, cg util.CallGraph) bool {
+	unsafe := false
+
+	switch keylen := keylen.(type) {
+	case *ssa.Const:
+		real_len := keylen.Int64()
+		if real_len < RECOMMENDED_KEYLEN {
+			unsafe = true
+		}
+	case *ssa.Phi:
+		for _, edge := range keylen.Edges {
+			if keylen != edge {
+				unsafe = unsafe || keylen_check(pass, edge, cg)
+			}
+		}
+	case *ssa.BinOp:
+		if val, ok := EvalConst(keylen, cg); ok {
+			unsafe = keylen_check(pass, val, cg)
+		}
+	case *ssa.Call:
+		if dest := keylen.Common().StaticCallee(); dest != nil {
+			returns := util.ReturnValues(dest)
+			for _, retval := range returns {
+				unsafe = unsafe || keylen_check(pass, retval[0], cg)
+			}
+		}
+	case *ssa.Parameter:
+		var values []*ssa.Value
+		values = cg.ResolveParam(keylen)
+		if len(values) > 0 {
+			unsafe = unsafe || keylen_check(pass, *values[0], cg)
+		}
+	}
+	return unsafe
+}
+
+// rsaRun runs the rsa keylength analyzer
+func rsaRun(pass *analysis.Pass) (interface{}, error) {
+	results := []util.Finding{}
+	// Builds SSA model of Go code
+	ssa_functions := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
+
+	// Creates call graph of function calls
+	call_graph := make(util.CallGraph)
+
+	// Fills in call graph
+	for _, fn := range ssa_functions {
+		call_graph.AnalyzeFunction(fn)
+	}
+
+	// Grabs vulnerable functions to scan for
+	vuln_rsa_funcs := vulnerableRsaFuncs()
+
+	// Iterate over every specified vulnerable package
+	for pkg, funcs := range vuln_rsa_funcs {
+
+		// Iterate over every specified vulnerable function per package
+		for _, fn := range funcs {
+
+			// Construct full name of function
+			current_function := pkg + "." + fn
+
+			// Iterate over occurrences of vulnerable function in call graph
+			for _, vulnFunc := range call_graph[current_function] {
+
+				// Check if argument of vulnerable function has keylen that is less than RECOMMENDED_KEYLEN
+				if keylen_check(pass, vulnFunc.Instr.Call.Args[1], call_graph) {
+					message := fmt.Sprintf("Danger: RSA key length is too short, recommend %d", RECOMMENDED_KEYLEN)
+					targetFunc := util.GenerateTaintedCode(pass, vulnFunc.Fn, vulnFunc.Instr.Pos())
+					results = append(results, util.MakeFinding(message, targetFunc, nil, "CWE-326: Inadequate Encryption Strength"))
+				}
+			}
+		}
+	}
+
+	return results, nil
+}

--- a/go_filtered_100/rsaBin.go
+++ b/go_filtered_100/rsaBin.go
@@ -1,0 +1,32 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+//There should be one insufficient key length in this file
+func bin() int {
+	tmp2 := 2045
+	keylenBin(tmp2)
+	return tmp2
+}
+// {fact rule=cryptographic-key-generator@v1.0 defects=1}
+func keylenBin(tmp2 int) {
+	rsa.GenerateKey(rand.Reader, tmp2+1)
+}
+// {/fact}

--- a/go_filtered_100/rsaBinPhi.go
+++ b/go_filtered_100/rsaBinPhi.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+//There should be one insufficient key length in this file
+func binPhi() int {
+	tmp2 := 2040
+	tmp3 := 6
+	if tmp2 == 2040 {
+		tmp3 = 50
+	}
+	keylenBinPhi(tmp2, tmp3)
+	return tmp2
+}
+// {fact rule=cryptographic-key-generator@v1.0 defects=0}
+func keylenBinPhi(tmp2 int, tmp3 int) {
+
+	rsa.GenerateKey(rand.Reader, tmp3+tmp2+1)
+}
+// {/fact}

--- a/go_filtered_100/rsa_case.go
+++ b/go_filtered_100/rsa_case.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/gokart/test/testutil"
+)
+
+func TestRsaKeylen(t *testing.T) {
+	testFiles := []string{
+		"rsa_direct_bad.go",
+		"rsa_direct_good.go",
+		"rsa_indirect_bad.go",
+		"rsa_indirect_good.go",
+		"rsa_phi_bad.go",
+		"rsa_phi_good.go",
+		"rsa_multiple_params_bad.go",
+		"rsa_multiple_params_good.go",
+		"rsa_multiple_issues.go",
+	}
+
+	// Append directory to each entry
+	for i := 0; i < len(testFiles); i++ {
+		testFiles[i] = "rsa_keylength/" + testFiles[i]
+	}
+
+	testResults := []int{
+		1,
+		0,
+		1,
+		0,
+		1,
+		0,
+		1,
+		0,
+		2,
+	}
+	for i := 0; i < len(testFiles); i++ {
+		t.Run(testFiles[i], func(t *testing.T) {
+			testutil.RunTest(testFiles[i], testResults[i], "CWE-326: Inadequate Encryption Strength", RsaKeylenAnalyzer, t)
+		})
+	}
+}

--- a/go_filtered_100/rsa_direct_bad.go
+++ b/go_filtered_100/rsa_direct_bad.go
@@ -1,0 +1,25 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+// {fact rule=cryptographic-key-generator@v1.0 defects=1}
+func rsa_main() {
+	rsa.GenerateKey(rand.Reader, 100)
+}
+// {/fact}

--- a/go_filtered_100/rsa_direct_good.go
+++ b/go_filtered_100/rsa_direct_good.go
@@ -1,0 +1,25 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+// {fact rule=cryptographic-key-generator@v1.0 defects=0}
+func rsa_main() {
+	rsa.GenerateKey(rand.Reader, 2048)
+}
+// {/fact}

--- a/go_filtered_100/rsa_indirect_bad.go
+++ b/go_filtered_100/rsa_indirect_bad.go
@@ -1,0 +1,30 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+func key_len() int {
+	return 1024
+}
+// {fact rule=cryptographic-key-generator@v1.0 defects=1}
+func rsa_main() {
+	keylen := key_len()
+	rsa.GenerateKey(rand.Reader, keylen+1)
+}
+// {/fact}

--- a/go_filtered_100/rsa_indirect_good.go
+++ b/go_filtered_100/rsa_indirect_good.go
@@ -1,0 +1,30 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+func key_len() int {
+	return 2048
+}
+// {fact rule=cryptographic-key-generator@v1.0 defects=0}
+func rsa_main() {
+	keylen := key_len()
+	rsa.GenerateKey(rand.Reader, keylen+1)
+}
+// {/fact}

--- a/go_filtered_100/rsa_multiple_issues.go
+++ b/go_filtered_100/rsa_multiple_issues.go
@@ -1,0 +1,42 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+//There should be two insufficient key length in this file
+
+func big() int {
+	tmp2 := 2040
+	tmp3 := 5
+	keylenBig(tmp2, tmp3)
+	return tmp2
+}
+
+func keylenBig(tmp2 int, tmp3 int) {
+	keylenBig2(tmp2)
+	rsa.GenerateKey(rand.Reader, tmp2+100)
+// {fact rule=cryptographic-key-generator@v1.0 defects=1}
+	rsa.GenerateKey(rand.Reader, tmp3+tmp2)
+}
+// {fact rule=cryptographic-key-generator@v1.0 defects=1}
+func keylenBig2(tmp2 int) {
+
+	rsa.GenerateKey(rand.Reader, tmp2)
+}
+// {/fact}

--- a/go_filtered_100/rsa_multiple_params_bad.go
+++ b/go_filtered_100/rsa_multiple_params_bad.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+//There should be one insufficient key length in this file
+
+func multipleParams() int {
+	tmp2 := 500
+	tmp3 := 1000
+	keylenMultParam(tmp2, tmp3)
+	return tmp2
+}
+// {fact rule=cryptographic-key-generator@v1.0 defects=1}
+func keylenMultParam(tmp2 int, tmp3 int) {
+	rsa.GenerateKey(rand.Reader, tmp2+tmp3)
+}
+// {/fact}

--- a/go_filtered_100/rsa_multiple_params_good.go
+++ b/go_filtered_100/rsa_multiple_params_good.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+//There should be one insufficient key length in this file
+
+func multipleParams() int {
+	tmp2 := 1024
+	tmp3 := 1024
+	keylenMultParam(tmp2, tmp3)
+	return tmp2
+}
+// {fact rule=cryptographic-key-generator@v1.0 defects=0}
+func keylenMultParam(tmp2 int, tmp3 int) {
+
+	rsa.GenerateKey(rand.Reader, tmp2+tmp3)
+}
+// {/fact}

--- a/go_filtered_100/rsa_phi_bad.go
+++ b/go_filtered_100/rsa_phi_bad.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+//There should be one insufficient key length in this file
+func phi() int {
+	tmp2 := 2040
+	tmp3 := 3000
+	if tmp2 == 2040 {
+		tmp3 = 50
+	}
+	keylenPhi(tmp2, tmp3)
+	return tmp2
+}
+// {fact rule=cryptographic-key-generator@v1.0 defects=1}
+func keylenPhi(tmp2 int, tmp3 int) {
+
+	rsa.GenerateKey(rand.Reader, tmp3)
+}
+// {/fact}

--- a/go_filtered_100/rsa_phi_good.go
+++ b/go_filtered_100/rsa_phi_good.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+//There should be one insufficient key length in this file
+func phi() int {
+	tmp2 := 2040
+	tmp3 := 3000
+	if tmp2 == 2040 {
+		tmp3 = 5000
+	}
+	keylenPhi(tmp2, tmp3)
+	return tmp2
+}
+// {fact rule=cryptographic-key-generator@v1.0 defects=0}
+func keylenPhi(tmp2 int, tmp3 int) {
+
+	rsa.GenerateKey(rand.Reader, tmp3)
+}
+// {/fact}

--- a/go_filtered_100/run.go
+++ b/go_filtered_100/run.go
@@ -1,0 +1,180 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package run controls the loading of go code and the running of analyzers.
+*/
+package run
+
+import (
+	"fmt"
+	"go/token"
+	"os"
+	"strings"
+
+	"github.com/praetorian-inc/gokart/util"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+	"golang.org/x/tools/go/packages"
+)
+
+// Load go packages and run the analyzers on them. Returns a list of findings
+func Run(analyzers []*analysis.Analyzer, packages ...string) ([]util.Finding, bool, error) {
+
+	pkgs, success, err := LoadPackages(packages...)
+	if err != nil {
+		return nil, false, err
+	}
+
+	results := []util.Finding{}
+	for _, pkg := range pkgs {
+		result, err := RunAnalyzers(analyzers, pkg)
+		if err != nil {
+			return nil, false, err
+		}
+		results = append(results, result...)
+	}
+
+	return results, success, nil
+
+}
+
+// Load go packages
+func LoadPackages(packagesList ...string) ([]*packages.Package, bool, error) {
+	success := true
+	conf := packages.Config{
+		Mode: packages.LoadSyntax,
+		//Disable loading tests. If we enable this, then packages will be loaded twice. Once with tests, once without.
+		//This causes us to report findings twice, even if there are no tests in the package
+		Tests: false,
+	}
+
+	//Load all packages that have been configured to be scanned, watch out for memory errors
+	pkgs, err := packages.Load(&conf, packagesList...)
+
+	if err != nil {
+		return nil, false, err
+	}
+	// Detect any packages that are unable to be scanned due to compilation or accessibility errors
+	badpkgs := make(map[*packages.Package]bool)
+	packages.Visit(pkgs, nil, func(pkg *packages.Package) {
+		if len(pkg.Errors) != 0 {
+			badpkgs[pkg] = true
+		}
+	})
+
+	if len(badpkgs) != 0 {
+		fmt.Fprintf(os.Stderr, "\nUh oh, a dashboard light is on! GoKart was unable to load the following packages: \n")
+		pkgs = RemoveBadPackages(pkgs, badpkgs)
+		fmt.Fprintf(os.Stderr, "\n\n")
+	}
+
+	// Print error message if no scannable packages are found
+	if len(pkgs) == 0 {
+		fmt.Fprintf(os.Stderr, "CRASH! GoKart didn't find any files to scan! Make sure the usage is correct to get GoKart back on track. \n"+
+			"If the usage appears to be correct, try pointing gokart at the directory from where you would run 'go build'. \n")
+		success = false
+	}
+	return pkgs, success, nil
+}
+
+// RemoveBadPackages takes the full list of packages and a map containing the packages that produced errors while being loaded.
+func RemoveBadPackages(allPackages []*packages.Package, badPackages map[*packages.Package]bool) []*packages.Package {
+	buf := new(strings.Builder)
+	goodPackages := make([]*packages.Package, 0, len(allPackages))
+	for _, pkg := range allPackages {
+		if badPackages[pkg] {
+			fmt.Fprintf(buf, "\n%s:\n", pkg.PkgPath)
+			for _, pkgError := range pkg.Errors {
+				fmt.Fprintf(buf, "- %s\n", pkgError.Error())
+			}
+		} else {
+			goodPackages = append(goodPackages, pkg)
+		}
+	}
+	fmt.Fprint(os.Stderr, buf.String())
+	return goodPackages
+}
+
+// Run analyzers on a package
+func RunAnalyzers(analyzers []*analysis.Analyzer, pkg *packages.Package) ([]util.Finding, error) {
+	//run ssa first since the other analyzers require it
+
+	ssaPass := &analysis.Pass{
+		Analyzer:          buildssa.Analyzer,
+		Fset:              pkg.Fset,
+		Files:             pkg.Syntax,
+		OtherFiles:        pkg.OtherFiles,
+		IgnoredFiles:      pkg.IgnoredFiles,
+		Pkg:               pkg.Types,
+		TypesInfo:         pkg.TypesInfo,
+		TypesSizes:        pkg.TypesSizes,
+		ResultOf:          nil,
+		Report:            nil,
+		ImportObjectFact:  nil,
+		ExportObjectFact:  nil,
+		ImportPackageFact: nil,
+		ExportPackageFact: nil,
+		AllObjectFacts:    nil,
+		AllPackageFacts:   nil,
+	}
+
+	ssaResult, err := ssaPass.Analyzer.Run(ssaPass)
+	if err != nil {
+		return nil, err
+	}
+
+	//feed the results of ssa into the other analyzers
+	resultMap := make(map[*analysis.Analyzer]interface{})
+	resultMap[buildssa.Analyzer] = ssaResult
+
+	results := []util.Finding{}
+
+	// Calculate number of Go files parsed
+	full_size := 0
+	pkg.Fset.Iterate(
+		func(f *token.File) bool {
+			full_size += 1
+			return true
+		})
+	util.FilesFound = full_size
+
+	for _, analyzer := range analyzers {
+		//run the analyzer
+		pass := &analysis.Pass{
+			Analyzer:          analyzer,
+			Fset:              pkg.Fset,
+			Files:             pkg.Syntax,
+			OtherFiles:        pkg.OtherFiles,
+			IgnoredFiles:      pkg.IgnoredFiles,
+			Pkg:               pkg.Types,
+			TypesInfo:         pkg.TypesInfo,
+			TypesSizes:        pkg.TypesSizes,
+			ResultOf:          resultMap,
+			Report:            func(d analysis.Diagnostic) {},
+			ImportObjectFact:  nil,
+			ExportObjectFact:  nil,
+			ImportPackageFact: nil,
+			ExportPackageFact: nil,
+			AllObjectFacts:    nil,
+			AllPackageFacts:   nil,
+		}
+		result, err := pass.Analyzer.Run(pass)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, (result.([]util.Finding))...)
+	}
+	return results, nil
+}

--- a/go_filtered_100/run_1.go
+++ b/go_filtered_100/run_1.go
@@ -1,0 +1,42 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/praetorian-inc/gokart/run"
+	"golang.org/x/tools/go/analysis"
+)
+
+func RunTest(file string, numResults int, resultsType string, analyzer *analysis.Analyzer, t *testing.T) {
+	_, b, _, _ := runtime.Caller(0)
+	basepath := filepath.Dir(b)
+	path := basepath + "/../testdata/vulnerablemodule/" + file
+	results, _, err := run.Run([]*analysis.Analyzer{analyzer}, "file="+path)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(results) != numResults {
+		t.Errorf("Expected %d results, found %d", numResults, len(results))
+	}
+	for _, result := range results {
+		if result.Type != resultsType {
+			t.Errorf("Expected type %s, found %s", resultsType, results[0].Type)
+		}
+	}
+}

--- a/go_filtered_100/run_case.go
+++ b/go_filtered_100/run_case.go
@@ -1,0 +1,72 @@
+package run
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/tools/go/packages"
+)
+
+var (
+	pkgFoo = &packages.Package{
+		ID: "foo",
+	}
+	pkgBar = &packages.Package{
+		ID: "bar",
+	}
+	pkgBaz = &packages.Package{
+		ID: "baz",
+	}
+)
+
+func TestRemoveBadPackages(t *testing.T) {
+	testCases := []struct {
+		name        string
+		badPackages map[*packages.Package]bool
+		want        []*packages.Package
+	}{
+		{
+			name:        "no bad packages",
+			badPackages: nil,
+			want:        []*packages.Package{pkgFoo, pkgBar, pkgBaz},
+		},
+		{
+			name: "one bad package",
+			badPackages: map[*packages.Package]bool{
+				pkgFoo: true,
+			},
+			want: []*packages.Package{pkgBar, pkgBaz},
+		},
+		{
+			name: "all packages are bad",
+			badPackages: map[*packages.Package]bool{
+				pkgFoo: true,
+				pkgBar: true,
+				pkgBaz: true,
+			},
+			want: []*packages.Package{},
+		},
+	}
+
+	sortSlices := cmp.Transformer("Sort", func(in []*packages.Package) []*packages.Package {
+		out := append([]*packages.Package(nil), in...)
+		sort.SliceStable(out, func(i, j int) bool {
+			return out[i].ID < out[j].ID
+		})
+		return out
+	})
+	cmpPkgs := cmp.Comparer(func(x, y *packages.Package) bool {
+		return x.ID == y.ID
+	})
+
+	allPackages := []*packages.Package{pkgFoo, pkgBar, pkgBaz}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RemoveBadPackages(allPackages, tc.badPackages)
+			if diff := cmp.Diff(tc.want, got, cmpPkgs, sortSlices); diff != "" {
+				t.Errorf("RemoveBadPackages(%v, %v) returned an unexpected diff (-want +got):\n%s", allPackages, tc.badPackages, diff)
+			}
+		})
+	}
+}

--- a/go_filtered_100/sarif.go
+++ b/go_filtered_100/sarif.go
@@ -1,0 +1,44 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"log"
+	"os"
+
+	"github.com/owenrumney/go-sarif/sarif"
+)
+
+var SarifReport *sarif.Report
+var SarifRun *sarif.Run
+
+func InitSarifReporting() {
+	report, err := sarif.New(sarif.Version210)
+	SarifReport = report
+	if err != nil {
+		log.Fatal(err)
+	}
+	SarifRun = sarif.NewRun("GoKart", "https://github.com/praetorian-inc/gokart")
+}
+
+func SarifRecordFinding(type_ string, message string, filename string, lineNumber int) {
+	vulnLoc := sarif.NewLocationWithPhysicalLocation(sarif.NewPhysicalLocation().WithArtifactLocation(sarif.NewSimpleArtifactLocation(filename)).WithRegion(sarif.NewSimpleRegion(lineNumber, lineNumber)))
+	SarifRun.AddResult(type_).WithMessage(sarif.NewTextMessage(message)).WithLocation(vulnLoc)
+}
+
+func SarifPrintReport() {
+	SarifReport.AddRun(SarifRun)
+	SarifReport.PrettyWrite(os.Stdout)
+}

--- a/go_filtered_100/scan.go
+++ b/go_filtered_100/scan.go
@@ -1,0 +1,97 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package cmd implements a simple command line interface using cobra
+*/
+package cmd
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/praetorian-inc/gokart/analyzers"
+	"github.com/praetorian-inc/gokart/util"
+	"github.com/spf13/cobra"
+)
+
+var yml string
+var exitCode bool
+var remoteModule string
+var outputPath string
+var remoteBranch string
+var keyFile string
+
+func init() {
+	goKartCmd.AddCommand(scanCmd)
+	scanCmd.Flags().BoolP("sarif", "s", false, "outputs findings in SARIF form")
+	scanCmd.Flags().BoolP("json", "j", false, "outputs findings in JSON")
+	scanCmd.Flags().BoolP("globalsTainted", "g", false, "marks global variables as dangerous")
+	scanCmd.Flags().BoolP("verbose", "v", false, "outputs full trace of taint analysis")
+	scanCmd.Flags().BoolP("debug", "d", false, "outputs debug logs")
+	scanCmd.Flags().BoolP("exitCode", "x", false, "return non-nil exit code on potential vulnerabilities or scanner failure")
+	scanCmd.Flags().StringVarP(&remoteModule, "remoteModule", "r", "", "Remote gomodule to scan")
+	scanCmd.Flags().StringVarP(&remoteBranch, "remoteBranch", "b", "", "Branch of remote module to scan")
+	scanCmd.Flags().StringVarP(&keyFile, "keyFile", "k", "", "SSH Keyfile to use for ssh authentication for remote git repository scanning")
+	scanCmd.Flags().StringVarP(&yml, "input", "i", "", "input path to custom yml file")
+	scanCmd.Flags().StringVarP(&outputPath, "output", "o", "", "file path to write findings output instead of stdout")
+	goKartCmd.MarkFlagRequired("scan")
+}
+
+var scanCmd = &cobra.Command{
+	Use:   "scan [flags] [directory]",
+	Short: "Scans a Go module directory",
+	Long: `
+Scans a Go module directory. To scan the current directory recursively, use gokart scan. To scan a specific directory, use gokart scan <directory>.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		sarif, _ := cmd.Flags().GetBool("sarif")
+		json, _ := cmd.Flags().GetBool("json")
+		globals, _ := cmd.Flags().GetBool("globalsTainted")
+		verbose, _ := cmd.Flags().GetBool("verbose")
+		debug, _ := cmd.Flags().GetBool("debug")
+		exitCode, _ := cmd.Flags().GetBool("exitCode")
+		util.InitConfig(globals, sarif, json, verbose, debug, outputPath, yml, exitCode)
+
+		// If remoteModule was set, clone the remote repository and scan it
+		if len(remoteModule) != 0 {
+			moduleTempDir, err := ioutil.TempDir(".", "gokart")
+			if err != nil {
+				log.Fatal("Error creating temporary directory: ", err.Error())
+			}
+			defer util.CleanupModule(moduleTempDir)
+
+			// Clone the module, if the output format is JSON or SARIF don't print any progress to stdout
+			err = util.CloneModule(moduleTempDir, remoteModule, remoteBranch, keyFile, json || sarif)
+
+			if err != nil {
+				util.CleanupModule(moduleTempDir)
+				log.Fatal("Error cloning remote repository: ", err.Error())
+			}
+			// If passing in a module - the other arguments are wiped out!
+			args = append([]string{}, moduleTempDir+"/...")
+		}
+
+		// recursively scan the current directory if no arguments are passed in
+		if len(args) == 0 {
+			args = append(args, "./...")
+		}
+
+		results, err := analyzers.Scan(args)
+		// If we have set the flag to return non-zero exit code for when results are found or the scanner fails, return 1
+		if exitCode && (err != nil || len(results) > 0) {
+			os.Exit(1)
+		}
+	},
+}

--- a/go_filtered_100/scan_1.go
+++ b/go_filtered_100/scan_1.go
@@ -1,0 +1,213 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package analyzers implements individual security scanners for Go
+and a generic analyzer based on recursive taint propagation
+*/
+package analyzers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/praetorian-inc/gokart/run"
+	"github.com/praetorian-inc/gokart/util"
+	"golang.org/x/tools/go/analysis"
+)
+
+var Analyzers = []*analysis.Analyzer{
+	RsaKeylenAnalyzer,
+	PathTraversalAnalyzer,
+	SQLInjectionAnalyzer,
+	CommandInjectionAnalyzer,
+	SSRFAnalyzer,
+}
+
+func FilterResults(unfilteredResults []util.Finding, parent_dir string) ([]util.Finding, error) {
+	filteredResults := []util.Finding{}
+
+	for _, finding := range unfilteredResults {
+		finding.Vulnerable_Function.SourceFilename = strings.TrimPrefix(finding.Vulnerable_Function.SourceFilename, parent_dir)
+		if finding.Untrusted_Source != nil {
+			for i, source := range finding.Untrusted_Source {
+				finding.Untrusted_Source[i].SourceFilename = strings.TrimPrefix(source.SourceFilename, parent_dir)
+			}
+		}
+		if util.IsValidFinding(finding) {
+			filteredResults = append(filteredResults, finding)
+		}
+	}
+
+	return filteredResults, nil
+}
+
+func OutputResults(results []util.Finding, success bool) error {
+	var outputColor = true
+// {fact rule=insecure-file-permissions@v1.0 defects=1}
+	if util.Config.OutputPath != "" {
+		// open file read/write | create if not exist | clear file at open if exists
+		outputFile, err := os.OpenFile(util.Config.OutputPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+		if err != nil {
+			return err
+		}
+		defer outputFile.Close()
+
+		var stdOutPipe = os.Stdout // keep backup of the real stdout
+		defer func() {
+			os.Stdout = stdOutPipe // restore the real stdout
+		}()
+		os.Stdout = outputFile
+		outputColor = false
+	}
+// {/fact}
+	if util.Config.OutputJSON && success {
+		res, err := json.Marshal(results)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(res))
+	}
+
+	for _, finding := range results {
+		util.OutputFinding(finding, outputColor)
+	}
+
+	// if packages were able to be scanned, print the correct output message
+	if util.Config.OutputSarif && success {
+		util.SarifPrintReport()
+		fmt.Println()
+	}
+
+	return nil
+}
+
+func Scan(args []string) ([]util.Finding, error) {
+	//Get the current dir so we can reset it later.
+	current_dir, err := os.Getwd()
+	if err != nil {
+		fmt.Printf("Unable to get current dir.\n")
+	}
+
+	if util.Config.OutputSarif {
+		util.InitSarifReporting()
+	} else if util.Config.OutputJSON {
+		// don't print out anything
+	} else {
+		fmt.Printf("\nRevving engines VRMMM VRMMM\n3...2...1...Go!\n")
+	}
+	// If we're given a target path, we do some slight changes to make sure that
+	// gokart will behave as expected. Specifically we turn the path into an absolute
+	// path, and then we append /... to the end to make sure the package loading is recursive.
+	// Finally we update the current working directory to the target
+	// In order to not cause issues we set the working directory back after we are done scanning.
+	if len(args) > 0 {
+		target_path := args[0]
+		if !filepath.IsAbs(target_path) {
+			target_path, _ = filepath.Abs(args[0])
+			args[0] = target_path
+		}
+
+		// Fix up the path to make sure it is pointed at a directory (even if given a file)
+		fileInfo, err := os.Stat(strings.TrimRight(target_path, "."))
+		if err != nil {
+			log.Fatal(err)
+		}
+		target_dir := filepath.Dir(target_path)
+		if fileInfo.IsDir() {
+			// Adding an extra / to the end of the path to make sure we still target the directory
+			target_dir = filepath.Dir(target_path + "/")
+		}
+
+		if !strings.HasSuffix(target_path, "...") {
+			target_path = filepath.Join(target_dir, "...")
+			args[0] = target_path
+			if util.Config.Debug {
+				fmt.Printf("Setting target_path to %s\n", args[0])
+			}
+		}
+
+		err = os.Chdir(strings.TrimRight(target_path, "."))
+		if err != nil {
+			log.Fatal(err)
+		}
+		cwd, _ := os.Getwd()
+		if util.Config.Debug {
+			fmt.Printf("Current working directory is %s\n", cwd)
+		}
+	}
+
+	generic_analyzers := LoadGenericAnalyzers()
+	Analyzers = append(Analyzers, generic_analyzers[:]...)
+
+	// Begin timer
+	run_begin_time := time.Now()
+	// Run analyzers
+	results, success, err := run.Run(Analyzers, args...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Calculate time taken
+	scan_time := time.Since(run_begin_time)
+
+	// Unless the argument given is an absolute path, the path to the source file for findings are trimmed
+	// to be relative to the most specific path shared by the argument and the current working directory.
+	parent_dir := ""
+	if len(args) > 0 && !filepath.IsAbs(args[0]) {
+		full_path, _ := filepath.Abs(args[0])
+		full_path = strings.TrimSuffix(full_path, "...")
+		cwd, _ := os.Getwd()
+		full_path_split := strings.Split(full_path, "/")[1:]
+		cwd_split := strings.Split(cwd, "/")[1:]
+		i := 0
+		for i < len(full_path_split) && i < len(cwd_split) && full_path_split[i] == cwd_split[i] {
+			parent_dir += "/" + full_path_split[i]
+			i++
+		}
+		parent_dir += "/"
+	}
+
+	// fix-up our results to exclude invalid results + shorten long directory names
+	filteredResults, err := FilterResults(results, parent_dir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// output findings to stdout or specified output file
+	err = OutputResults(filteredResults, success)
+	if err != nil {
+		log.Fatalf("Error opening output file: %v", err)
+	}
+
+	// Don't print out messages if JSON or SARIF output
+	if !(util.Config.OutputSarif || util.Config.OutputJSON) && success {
+		fmt.Println("\nRace Complete! Analysis took", scan_time, "and", util.FilesFound, "Go files were scanned (including imported packages)")
+		fmt.Printf("GoKart found %d potentially vulnerable functions\n", len(filteredResults))
+		// display information about all findings
+		util.OutputFindingMetadata(filteredResults, true)
+	}
+	os.Chdir(current_dir)
+
+	if !success {
+		return nil, errors.New("gokart could not find any packages to scan")
+	}
+
+	return filteredResults, nil
+}

--- a/go_filtered_100/scan_case.go
+++ b/go_filtered_100/scan_case.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/gokart/util"
+	"github.com/spf13/cobra"
+)
+
+func TestScanCommand(t *testing.T) {
+	// Tests the Scan command.
+	cur_dir, err := os.Getwd()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Printf("Current dir is: %s", cur_dir)
+	var tests = []struct {
+		args              []string
+		expected_lastline string
+		moduledir         string
+	}{
+		{[]string{"scan"}, "GoKart found 0 potentially vulnerable functions", ""},
+		{[]string{"scan", "-r", "https://github.com/praetorian-inc/gokart"}, "GoKart found 0 potentially vulnerable functions", cur_dir + "/gokart"},
+		{[]string{"scan", "--help"}, "  -v, --verbose               outputs full trace of taint analysis", ""},
+	}
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, " "), func(t *testing.T) {
+
+			if err != nil {
+				t.Fatalf("Failed! %s", err)
+			}
+
+			// fetch last line of output from scan command
+			lastline := ExecuteCommand(goKartCmd, tt.args)
+			//if we tested with a remote module clean it up.
+			if len(tt.moduledir) != 0 {
+				err := util.CleanupModule(tt.moduledir)
+				if err != nil {
+					fmt.Print(err)
+				}
+			}
+			if lastline != tt.expected_lastline {
+				t.Fatalf("Failed! Expected: %s\nGot: %s\n", tt.expected_lastline, lastline)
+			}
+		})
+	}
+}
+
+func ExecuteCommand(cmd *cobra.Command, args []string) string {
+
+	// change stdout to something we can read from to capture command out
+	// Not sure if this could potentially cause issues if buffer gets too full
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	os.Stderr = w
+
+	cmd.SetArgs(args)
+	Execute()
+
+	// reset stdout to normal stdout and read output from cmd
+	w.Close()
+	stdoutres, _ := ioutil.ReadAll(r)
+	os.Stdout = old
+
+	//get the last line of output for comparison with our tests
+	stdoutresslice := strings.Split(strings.ReplaceAll(string(stdoutres), "\r\n", "\n"), "\n")
+	lastline := stdoutresslice[len(stdoutresslice)-2]
+	return lastline
+
+}

--- a/go_filtered_100/serverCase.go
+++ b/go_filtered_100/serverCase.go
@@ -1,0 +1,151 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"crypto/rand"
+	"crypto/rsa"
+	"database/sql"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+)
+
+var (
+	db5        *sql.DB
+	globalTest int = 500
+)
+// {fact rule=insecure-connection@v1.0 defects=1}
+func main() {
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}
+// {/fact}
+func handler(w http.ResponseWriter, r *http.Request) {
+
+	keys, ok := r.URL.Query()["key"]
+
+	if !ok || len(keys[0]) < 1 {
+		log.Println("Url Param 'key' is missing")
+		return
+	}
+
+	// Query()["key"] will return an array of items,
+	// we only want the single item.
+// {fact rule=path-traversal@v1.0 defects=1}
+	// path traversal
+	key := keys[0]
+	f, _ := os.Create(key)
+	f.Close()
+	log.Println("Url Param 'key' is: " + string(key))
+	os.Open(key)
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=1}
+	// sql injection
+	reader := bufio.NewReader(os.Stdin)
+	hiddenMessage, _ := reader.ReadString('\n')
+	db5.Query("SELECT name FROM users WHERE username=" + hiddenMessage)
+	db5.Query("SELECT name FROM users WHERE username=" + key)
+// {/fact}
+
+	// command injection
+	if key == "safe" {
+		key = "safe"
+	}
+	cmd := exec.Command("echo", key, "Yes it is.")
+	cmd.Run()
+// {fact rule=cryptographic-key-generator@v1.0 defects=1}
+	// RSA
+	rsa.GenerateKey(rand.Reader, 1050)
+// {/fact}
+
+// {fact rule=cryptographic-key-generator@v1.0 defects=1}
+	//testing global variable
+	rsa.GenerateKey(rand.Reader, globalTest)
+// {/fact}
+	//from here down should only be false positives
+
+// {fact rule=path-traversal@v1.0 defects=1}
+	//directory trav safe scenarios
+	tmp := "./list1/images/"
+	x := 5
+	if x != 5 {
+		tmp = "./etc/passwd"
+	}
+	DirTraversal6(tmp)
+	os.Open(temp8(key)) //another false negative here by gosec!!
+// {/fact}
+
+// {fact rule=cryptographic-key-generator@v1.0 defects=0}
+	// rsa safe scenario
+	tmp2 := 200
+	tmp3 := 1000
+	keylenMultParam(tmp2, tmp3)
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=0}
+	//sql safe scenarios
+	db5.Query("SELECT name FROM users WHERE username=" + temp7())
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=0}
+	db5.Query("SELECT name FROM users WHERE username=" + "dummy")
+// {/fact}
+
+// {fact rule=os-command-injection@v1.0 defects=0}
+	//command injection safe scenarios
+	msg := "This echo is safe."
+	exec.Command("echo", msg, "Yes it is.")
+// {/fact}
+
+// {fact rule=os-command-injection@v1.0 defects=0}
+	exec.Command("echo", temp7(), "Yes it is.")
+// {/fact}
+}
+
+func keylenMultParam(tmp2 int, tmp3 int) {
+	rsa.GenerateKey(rand.Reader, tmp2+tmp3) //gosec false negative??
+}
+
+
+
+func DirTraversal6(folderPath string) {
+	f2, _ := os.Create(folderPath)
+	os.Open(folderPath)
+
+	x5 := "safe"
+	num := 1000
+	cmdInjection(x5, num)
+	f2.Close()
+}
+
+func temp7() string {
+	return "a"
+}
+func temp8(key string) string {
+	return key
+}
+
+// {fact rule=os-command-injection@v1.0 defects=0}
+func cmdInjection(x string, num int) {
+	cmd := exec.Command(x)
+	cmd.Run()
+	rsa.GenerateKey(rand.Reader, num+50) // false negative in gosec??? Look into this
+	db5.Query("SELECT name FROM users WHERE username=" + x)
+}
+// {/fact}

--- a/go_filtered_100/sql1.go
+++ b/go_filtered_100/sql1.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+/*
+* There should be 2 vulnerability
+ */
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+)
+
+var (
+	ctx context.Context
+
+	db1 *sql.DB
+)
+
+func temp() string {
+	return "a"
+}
+func query(x string) {
+// {fact rule=sql-injection@v1.0 defects=0}
+	a := "asdf"
+	db1.Query("SELECT name FROM users WHERE username=" + a)
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=0}
+	db1.Query("SELECT name FROM users WHERE username=" + temp())
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=1}
+	db1.Query("SELECT name FROM users WHERE username=" + x)
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=0}
+	db1.Query(fmt.Sprintf("SELECT name FROM users WHERE username= %s", a))
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=1}
+	db1.Query(fmt.Sprintf("SELECT name FROM users WHERE username= %s", x))
+// {/fact}
+}
+
+func Sqlmain() {
+	reader := bufio.NewReader(os.Stdin)
+	hiddenMessage, _ := reader.ReadString('\n')
+	query(hiddenMessage + "abc")
+}

--- a/go_filtered_100/sql2.go
+++ b/go_filtered_100/sql2.go
@@ -1,0 +1,81 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+/*
+* There should be no vulnerabilities
+ */
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+)
+
+var (
+	ctx2 context.Context
+	db2  *sql.DB
+)
+
+func getSalt() string {
+	return "5678"
+}
+// {fact rule=sql-injection@v1.0 defects=0}
+func makequery(input string) {
+	db2.Query("SELECT name FROM users WHERE username=" + input)
+}
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=0}
+func makequery2(input string) {
+	db2.Query("SELECT name FROM users WHERE username=" + input)
+}
+// {/fact}
+
+func makequery3(s string, i int) {
+// {fact rule=sql-injection@v1.0 defects=0}
+	db2.Query(fmt.Sprintf("SELECT name FROM users WHERE username= %s", s))
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=0}
+	db2.Query(fmt.Sprintf("SELECT name FROM users WHERE username=admin OR 1=%d", i))
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=0}
+	converted := strconv.Itoa(i)
+	db2.Query("SELECT name FROM users WHERE username=admin OR 1=" + converted)
+// {/fact}
+}
+
+func middleman(hiddenMessage string) {
+	salt := "1234"
+	makequery(hiddenMessage + salt)
+}
+
+func middleman2(hiddenMessage string) {
+	makequery2(hiddenMessage + getSalt())
+}
+
+func middleman3(hiddenMessage string, secretMessage int) {
+	makequery3(hiddenMessage, secretMessage+5)
+}
+
+func toplevel() {
+	hiddenMessage := "This is safe"
+	middleman(hiddenMessage)
+	middleman2(hiddenMessage)
+	middleman3(hiddenMessage, 5)
+}

--- a/go_filtered_100/sql3.go
+++ b/go_filtered_100/sql3.go
@@ -1,0 +1,88 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+/*
+* There should be 5 vulnerabilities
+ */
+
+import (
+	"bufio"
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+var (
+	db4 *sql.DB
+)
+
+func three_getSalt() string {
+	return "5678"
+}
+// {fact rule=sql-injection@v1.0 defects=1}
+func three_makequery(input string) {
+	db4.Query("SELECT name FROM users WHERE username=" + input)
+}
+// {/fact}
+// {fact rule=sql-injection@v1.0 defects=1}
+func three_makequery2(input string) {
+	db4.Query("SELECT name FROM users WHERE username=" + input)
+}
+// {/fact}
+
+func three_makequery3(s string, i int) {
+// {fact rule=sql-injection@v1.0 defects=1}
+	db4.Query(fmt.Sprintf("SELECT name FROM users WHERE username= %s", s))
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=1}
+	db4.Query(fmt.Sprintf("SELECT name FROM users WHERE username=admin OR 1=%d", i))
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=1}
+	converted := strconv.Itoa(i)
+	db4.Query("SELECT name FROM users WHERE username=admin OR 1=" + converted)
+// {/fact}
+}
+
+func three_mthree_middlemaniddleman(hiddenMessage string) {
+	salt := "1234"
+	three_makequery(hiddenMessage + salt)
+}
+
+func three_middleman2(hiddenMessage string) {
+	three_makequery2(hiddenMessage + three_getSalt())
+}
+
+func three_middleman3(hiddenMessage string, secretMessage int) {
+	three_makequery3(hiddenMessage, secretMessage+5)
+}
+
+func three_toplevel(unsafe int) {
+	reader := bufio.NewReader(os.Stdin)
+	hiddenMessage, _ := reader.ReadString('\n')
+	three_middleman(hiddenMessage)
+	three_middleman2(hiddenMessage)
+	three_middleman3(hiddenMessage, unsafe)
+}
+
+func three_sqlmain() {
+	reader := bufio.NewReader(os.Stdin)
+	str, _ := reader.ReadString('\n')
+	hiddenInt, _ := strconv.Atoi(str)
+	three_toplevel(hiddenInt)
+}

--- a/go_filtered_100/sql4_formatstr.go
+++ b/go_filtered_100/sql4_formatstr.go
@@ -1,0 +1,58 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+/*
+* There should be 2 vulnerabilities
+ */
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+var (
+	ctx3 context.Context
+	db3  *sql.DB
+)
+
+func four_makequery3(s string, i int) {
+	//db3.Query(fmt.Sprintf("SELECT name FROM users WHERE username= %s", s))
+	//db3.Query(fmt.Sprintf("SELECT name FROM users WHERE username=admin OR 1=%d", i))
+	//converted := strconv.Itoa(i)
+	//db3.Query("SELECT name FROM users WHERE username=admin OR 1=" + converted)
+// {fact rule=sql-injection@v1.0 defects=1}
+	db3.Query(fmt.Sprintf("SELECT 1 = %s", s))
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=1}
+	db3.Query(fmt.Sprintf("SELECT 2=%d", i))
+// {/fact}
+
+// {fact rule=sql-injection@v1.0 defects=1}
+	converted := strconv.Itoa(i)
+	db3.Query("SELECT 3=" + converted)
+}
+// {/fact}
+func four_sqlmain() {
+	reader := bufio.NewReader(os.Stdin)
+	str, _ := reader.ReadString('\n')
+	hiddenInt, _ := strconv.Atoi(str)
+	four_makequery3("string", hiddenInt)
+}

--- a/go_filtered_100/sqli.go
+++ b/go_filtered_100/sqli.go
@@ -1,0 +1,90 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"strings"
+
+	"github.com/praetorian-inc/gokart/util"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+)
+
+// SQLInjectionAnalyzer constructs Sinks from a set of functions known to be vulnerable to SQL injection
+// all variables are converted to SSA form and a call graph is constructed
+// recursive taint analysis is then used to search from a given Sink up the callgraph for Sources of user-controllable data
+var SQLInjectionAnalyzer = &analysis.Analyzer{
+	Name:     "sql_injection",
+	Doc:      "reports when SQL injection can occur",
+	Run:      sqlRun,
+	Requires: []*analysis.Analyzer{buildssa.Analyzer},
+}
+
+// grab_vulnerable_sql_functions() creates map of vulnerable functions that the scanner will check
+func getVulnSqlFuncs() map[string][]string {
+	return map[string][]string{
+		"(*database/sql.DB)": {"Exec", "ExecContext", "Query", "QueryContext", "QueryRow", "QueryRowContext"},
+	}
+}
+
+// sql_run runs the path traversal analyzer
+func sqlRun(pass *analysis.Pass) (interface{}, error) {
+	results := []util.Finding{}
+	// Builds SSA model of Go code
+	ssaFuncs := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
+
+	// Creates call graph of function calls
+	cg := make(util.CallGraph)
+
+	// Fills in call graph
+	for _, fn := range ssaFuncs {
+		cg.AnalyzeFunction(fn)
+	}
+
+	// Grabs vulnerable functions to scan for
+	vuln_db_funcs := getVulnSqlFuncs()
+
+	// Iterate over every specified vulnerable package
+	for pkg, funcs := range vuln_db_funcs {
+
+		// Iterate over every specified vulnerable function per package
+		for _, fn := range funcs {
+
+			// Construct full name of function
+			current_function := pkg + "." + fn
+
+			// For SQL injections we only care about the argument that holds the query string (index 1 for normal query and index 2 for Context query)
+			argIndex := 1
+			if strings.Contains(current_function, "Context") {
+				argIndex = 2
+			}
+
+			// Iterate over occurrences of vulnerable function in call graph
+			for _, vulnFunc := range cg[current_function] {
+
+				// Check if argument of vulnerable function is tainted by possibly user-controlled input
+				taint_analyzer := util.CreateTaintAnalyzer(pass, vulnFunc.Fn.Pos())
+				if taint_analyzer.ContainsTaint(&vulnFunc.Instr.Call, &vulnFunc.Instr.Call.Args[argIndex], cg) {
+					message := "Danger: possible SQL injection detected"
+					targetFunc := util.GenerateTaintedCode(pass, vulnFunc.Fn, vulnFunc.Instr.Pos())
+					taintSource := taint_analyzer.TaintSource
+					results = append(results, util.MakeFinding(message, targetFunc, taintSource, "CWE-89: SQL Injection"))
+				}
+			}
+		}
+	}
+
+	return results, nil
+}

--- a/go_filtered_100/sqli_case.go
+++ b/go_filtered_100/sqli_case.go
@@ -1,0 +1,45 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/gokart/test/testutil"
+)
+
+func TestSQLInjection(t *testing.T) {
+	testFiles := []string{
+		"sql1.go",
+		"sql2.go",
+		"sql3.go",
+	}
+
+	// Append directory to each entry
+	for i := 0; i < len(testFiles); i++ {
+		testFiles[i] = "sql_injection/" + testFiles[i]
+	}
+
+	testResults := []int{
+		2,
+		0,
+		5,
+	}
+	for i := 0; i < len(testFiles); i++ {
+		t.Run(testFiles[i], func(t *testing.T) {
+			testutil.RunTest(testFiles[i], testResults[i], "CWE-89: SQL Injection", SQLInjectionAnalyzer, t)
+		})
+	}
+}

--- a/go_filtered_100/ssrf.go
+++ b/go_filtered_100/ssrf.go
@@ -1,0 +1,182 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"github.com/praetorian-inc/gokart/util"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+	"golang.org/x/tools/go/ssa"
+)
+
+// SSRF Analyzer constructs Sinks from a set of functions known to be vulnerable to Server Side Request Forgery,
+// converts all variables to SSA form to construct a call graph and performs
+// recursive taint analysis to search for input sources of user-controllable data
+var SSRFAnalyzer = &analysis.Analyzer{
+	Name:     "SSRF",
+	Doc:      "reports when SSRF vulnerabilities can occur",
+	Run:      ssrfRun,
+	Requires: []*analysis.Analyzer{buildssa.Analyzer},
+}
+
+// vulnerable_ssrf_funcs() returns a map of networking functions that may be vulnerable when used with user controlled input
+func vulnSsrfFuncs() map[string][]string {
+	return map[string][]string{
+		"net/http":           {"Do", "Get", "Head", "Post", "PostForm"},
+		"(*net/http.Client)": {"Do", "Get", "Head", "Post", "PostForm"},
+	}
+}
+
+func taintCheck(val *ssa.Value) bool {
+	//Alloc of http client
+	alloc, ok := (*val).(*ssa.Alloc)
+	if ok {
+		refs := alloc.Referrers()
+		for _, ref := range *refs {
+			//fieldAddr of http client
+			fieldAddr, ok := (ref).(*ssa.FieldAddr)
+			if !ok {
+				continue
+			}
+
+			//refs to that field
+			refs = fieldAddr.Referrers()
+			for _, ref := range *refs {
+				store, ok := (ref).(*ssa.Store)
+				if !ok {
+					continue
+				}
+				makeInterface, ok := store.Val.(*ssa.MakeInterface)
+				if !ok {
+					continue
+				}
+				transportAlloc, ok := makeInterface.X.(*ssa.Alloc)
+				if !ok {
+					continue
+				}
+				refs = transportAlloc.Referrers()
+				for _, ref := range *refs {
+					fieldAddr, ok = (ref).(*ssa.FieldAddr)
+					if !ok || fieldAddr.Type().String() != "*func(ctx context.Context, network string, addr string) (net.Conn, error)" {
+						continue
+					}
+					//refs to that field
+					refs = fieldAddr.Referrers()
+					for _, ref := range *refs {
+						store, ok = (ref).(*ssa.Store)
+						if !ok {
+							continue
+						}
+						closure, ok := store.Val.(*ssa.MakeClosure)
+						if !ok {
+							continue
+						}
+						for _, binding := range closure.Bindings {
+							transportAlloc, ok := binding.(*ssa.Alloc)
+							if !ok {
+								continue
+							}
+
+							refs = transportAlloc.Referrers()
+							for _, ref := range *refs {
+								fieldAddr, ok = (ref).(*ssa.FieldAddr)
+								if !ok || fieldAddr.Type().String() != "*func(network string, address string, c syscall.RawConn) error" {
+									continue
+								}
+								refs = fieldAddr.Referrers()
+								for _, ref := range *refs {
+									store, ok = (ref).(*ssa.Store)
+									if !ok {
+										continue
+									}
+									if store.Val.String() != "nil:func(network string, address string, c syscall.RawConn) error" {
+										return false
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+// ssrfRun() runs the command injection analyzer
+func ssrfRun(pass *analysis.Pass) (interface{}, error) {
+	results := []util.Finding{}
+
+	// Builds SSA model of Go code
+	ssaFuncs := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
+
+	// Creates call graph of function calls
+	cg := make(util.CallGraph)
+
+	// Fills in call graph
+	for _, fn := range ssaFuncs {
+		cg.AnalyzeFunction(fn)
+	}
+
+	// Grabs vulnerable functions to scan for
+	vuln_path_funcs := vulnSsrfFuncs()
+
+	// Iterate over every specified vulnerable package
+	for pkg, funcs := range vuln_path_funcs {
+
+		// Iterate over every specified vulnerable function per package
+		for _, fn := range funcs {
+
+			// Construct full name of function
+			curFunc := pkg + "." + fn
+			// Iterate over occurrences of vulnerable function in call graph
+			for _, vulnFunc := range cg[curFunc] {
+				// Check if argument of vulnerable function is tainted by possibly user-controlled input
+				taintAnalyzer := util.CreateTaintAnalyzer(pass, vulnFunc.Fn.Pos())
+				//the first arg of any http client calls is the client itself we don't care about checking this for
+				//taint since it's not part of the SSRF however, if the control attribute is set on the client then we
+				//know it's safe, and we should never mark it as tainted (even if there is a get with user controlled
+				//input)
+				if pkg == "(*net/http.Client)" {
+					if taintCheck(&vulnFunc.Instr.Call.Args[0]) {
+						for i := 1; i < len(vulnFunc.Instr.Call.Args); i++ {
+							if taintAnalyzer.ContainsTaint(&vulnFunc.Instr.Call, &vulnFunc.Instr.Call.Args[i], cg) {
+								message := "Danger: possible SSRF detected"
+								targetFunc := util.GenerateTaintedCode(pass, vulnFunc.Fn, vulnFunc.Instr.Pos())
+								taintSource := taintAnalyzer.TaintSource
+								results = append(results, util.MakeFinding(message, targetFunc, taintSource, "CWE-918: Server-Side Request Forgery"))
+
+							}
+						}
+					}
+				} else {
+					for i := 0; i < len(vulnFunc.Instr.Call.Args); i++ {
+						if taintAnalyzer.ContainsTaint(&vulnFunc.Instr.Call, &vulnFunc.Instr.Call.Args[i], cg) {
+							message := "Danger: possible SSRF detected"
+							targetFunc := util.GenerateTaintedCode(pass, vulnFunc.Fn, vulnFunc.Instr.Pos())
+							taintSource := taintAnalyzer.TaintSource
+							results = append(results, util.MakeFinding(message, targetFunc, taintSource, "CWE-918: Server-Side Request Forgery"))
+
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return results, nil
+}

--- a/go_filtered_100/ssrf_1.go
+++ b/go_filtered_100/ssrf_1.go
@@ -1,0 +1,28 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"net/http"
+	"os"
+)
+// {fact rule=server-side-request-forgery@v1.0 defects=1}
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	untrusted, _ := reader.ReadString('\n')
+	_, _ = http.Get(untrusted)
+}
+// {/fact}

--- a/go_filtered_100/ssrf_alloc_taint.go
+++ b/go_filtered_100/ssrf_alloc_taint.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"net/http"
+	"os"
+)
+// {fact rule=server-side-request-forgery@v1.0 defects=1}
+func main() {
+	buf := make([]byte, 20)
+	reader := bufio.NewReader(os.Stdin)
+	untrusted, _ := reader.ReadString('\n')
+	copy(buf, []byte(untrusted))
+	//buf[0] = 3
+	_, _ = http.Get(string(buf))
+}
+// {/fact}

--- a/go_filtered_100/ssrf_case.go
+++ b/go_filtered_100/ssrf_case.go
@@ -1,0 +1,53 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/gokart/test/testutil"
+)
+
+func TestSSRF(t *testing.T) {
+	testFiles := []string{
+		"ssrf.go",
+		"ssrf_alloc_taint.go",
+		"ssrf_client.go",
+		"ssrf_client_good.go",
+		"ssrf_good.go",
+		"ssrf_client_control.go",
+		"ssrf_struct.go",
+	}
+
+	// Append directory to each entry
+	for i := 0; i < len(testFiles); i++ {
+		testFiles[i] = "ssrf/" + testFiles[i]
+	}
+
+	testResults := []int{
+		1,
+		1,
+		1,
+		0,
+		0,
+		0,
+		1,
+	}
+	for i := 0; i < len(testFiles); i++ {
+		t.Run(testFiles[i], func(t *testing.T) {
+			testutil.RunTest(testFiles[i], testResults[i], "CWE-918: Server-Side Request Forgery", SSRFAnalyzer, t)
+		})
+	}
+}

--- a/go_filtered_100/ssrf_client.go
+++ b/go_filtered_100/ssrf_client.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	safeDialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+		Control:   nil,
+	}
+
+	safeTransport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           safeDialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+// {fact rule=server-side-request-forgery@v1.0 defects=1}
+	safeClient := &http.Client{
+		Transport: safeTransport,
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	untrusted, _ := reader.ReadString('\n')
+	_, _ = safeClient.Get(untrusted)
+}
+// {/fact}

--- a/go_filtered_100/ssrf_client_control.go
+++ b/go_filtered_100/ssrf_client_control.go
@@ -1,0 +1,56 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"time"
+)
+
+func safeSocketControl(network string, address string, conn syscall.RawConn) error {
+	return nil
+}
+
+func main() {
+	safeDialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+		Control:   safeSocketControl,
+	}
+
+	safeTransport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           safeDialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+// {fact rule=server-side-request-forgery@v1.0 defects=1}
+	safeClient := &http.Client{
+		Transport: safeTransport,
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	untrusted, _ := reader.ReadString('\n')
+	_, _ = safeClient.Get(untrusted)
+}
+// {/fact}

--- a/go_filtered_100/ssrf_client_good.go
+++ b/go_filtered_100/ssrf_client_good.go
@@ -1,0 +1,47 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+func main() {
+	safeDialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+		Control:   nil,
+	}
+
+	safeTransport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           safeDialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+// {fact rule=server-side-request-forgery@v1.0 defects=0}
+	safeClient := &http.Client{
+		Transport: safeTransport,
+	}
+
+	_, _ = safeClient.Get("google.com")
+}
+// {/fact}

--- a/go_filtered_100/ssrf_good.go
+++ b/go_filtered_100/ssrf_good.go
@@ -1,0 +1,23 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/http"
+)
+
+func main() {
+	_, _ = http.Get("google.com")
+}

--- a/go_filtered_100/ssrf_struct.go
+++ b/go_filtered_100/ssrf_struct.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"net/http"
+	"os"
+)
+
+type Wrapper struct {
+	Val string
+}
+// {fact rule=server-side-request-forgery@v1.0 defects=1}
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+	untrusted, _ := reader.ReadString('\n')
+	wrapper := Wrapper{
+		Val: untrusted,
+	}
+	_, _ = http.Get(wrapper.Val)
+}
+// {/fact}

--- a/go_filtered_100/taint.go
+++ b/go_filtered_100/taint.go
@@ -1,0 +1,356 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"go/token"
+	"log"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+// TaintedCode is a struct that contains information about the vulnerable line of code
+type TaintedCode struct {
+	SourceCode     string
+	SourceFilename string
+	SourceLineNum  int
+	ParentFunction string
+}
+
+//MapData is a struct that contains information about each hash
+type MapData struct {
+	Mapped     bool // whether a hash has already been mapped
+	Vulnerable bool // whether a hash has been found vulnerable
+	Count      int  // the number of times a hash has been visited
+}
+
+// TaintAnalyzer is a struct that contains information about each taint analyzer
+type TaintAnalyzer struct {
+	taint_map   map[uint64]MapData
+	TaintSource []TaintedCode
+	pass        *analysis.Pass
+	location    token.Pos
+}
+
+// CreateTaintAnalyzer returns a new TaintAnalyzer struct
+func CreateTaintAnalyzer(pass *analysis.Pass, location token.Pos) TaintAnalyzer {
+	return TaintAnalyzer{
+		make(map[uint64]MapData),
+		[]TaintedCode{},
+		pass,
+		location,
+	}
+}
+
+// ContainsTaint analyzes the ssa.Value, recursively traces the value to all possible sources, and returns True if any of the sources are vulnerable. It returns False otherwise.
+func (ta *TaintAnalyzer) ContainsTaint(startCall *ssa.CallCommon, val *ssa.Value, cg CallGraph) bool {
+	return ta.ContainsTaintRecurse(startCall, val, cg, 0, []ssa.Value{})
+}
+
+func (ta *TaintAnalyzer) ContainsTaintRecurse(startCall *ssa.CallCommon, val *ssa.Value, cg CallGraph, depth int, visitedMutable []ssa.Value) bool {
+	if *val == nil {
+		return false
+	}
+	if Config.Debug {
+		out := ""
+		for i := 0; i < depth; i++ {
+			out += "  "
+		}
+		log.Printf("%s%s (%T)\n", out, *val, *val)
+	}
+
+	call, isCall := (*val).(*ssa.Call)
+	if isCall {
+		//A function call cannot become tainted from itself This is due to a bug with how we handle referrers. Since we
+		//check all function calls, past and future, we need to make sure to ignore the starting function call
+		//This makes sure we dont duplicate findings by having one parameter infect other parameters
+		if startCall == &call.Call {
+			return false
+		}
+	}
+
+	//We have already seen this buffer, assume its fine
+	for _, visitedVal := range visitedMutable {
+		if *val == visitedVal {
+			return false
+		}
+	}
+
+	// Memoize the ssa.Value
+	map_status1 := ta.taint_map[SSAvalToHash(val)]
+	ta.Memoize(val, map_status1.Vulnerable)
+	// Store the memoization status in map_status
+	map_status := ta.taint_map[SSAvalToHash(val)]
+
+	// if the ssa.Value hash has been seen over fifty times, return false because it is likely an infinite loop
+	if map_status.Count > 20 {
+		if Config.Debug {
+			log.Printf("Overflow detected, breaking the infinite loop")
+		}
+
+		return false
+	}
+	// if the ssa.Value hash has already been mapped, return it's vulnerable status
+	if map_status.Mapped {
+		return map_status.Vulnerable
+	}
+
+	//default set vulnerable to false, this may not be necessary anymore
+	vulnerable := false
+
+	switch expr := (*val).(type) {
+	case *ssa.Const:
+		vulnerable = false
+	case *ssa.Parameter:
+		// Check if this function call is part of the tainted function source list
+		globalPkgName := (expr).Parent().Pkg.Pkg.Name()
+		if val, ok := VulnGlobalFuncs[globalPkgName]; ok {
+			for _, funcName := range val {
+				if (expr).Name() == funcName {
+					vulnerable = true
+				}
+			}
+		}
+
+		for pkg, types_ := range VulnTypes {
+			for _, type_ := range types_ {
+				if strings.TrimPrefix(expr.Type().String(), "*") == pkg+"."+type_ {
+					vulnerable = true
+				}
+			}
+		}
+
+		var values []*ssa.Value
+		values = cg.ResolveParam(expr)
+		if len(values) > 0 {
+			vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, values[0], cg, depth+1, visitedMutable) //loop B
+		}
+	case *ssa.FreeVar:
+		vulnerable = false
+	case *ssa.Function:
+		// Assume that the user cannot create their own functions
+		vulnerable = false
+	case *ssa.Field:
+		vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable)
+	case *ssa.Next:
+		vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, &expr.Iter, cg, depth+1, visitedMutable)
+	case *ssa.TypeAssert:
+		vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable)
+	case *ssa.Range:
+		vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable)
+	case *ssa.Phi:
+		mapping := MapData{Mapped: true, Vulnerable: false}
+		ta.taint_map[SSAvalToHash(val)] = mapping
+		for _, edge := range (*expr).Edges {
+
+			// this if statement is to prevent infiinite loop
+			if edge != expr {
+				vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, &edge, cg, depth+1, visitedMutable)
+			}
+		}
+	case *ssa.UnOp:
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable)
+	case *ssa.BinOp:
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable) || ta.ContainsTaintRecurse(startCall, &expr.Y, cg, depth+1, visitedMutable)
+	case *ssa.Extract:
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.Tuple, cg, depth+1, visitedMutable)
+	case *ssa.Call:
+		callFunc, ok := (expr.Call.Value).(*ssa.Function)
+		if ok {
+			globalPkgName := callFunc.Pkg.Pkg.Name()
+			if val, ok := VulnGlobalFuncs[globalPkgName]; ok {
+				for _, funcName := range val {
+					if callFunc.Name() == funcName {
+						vulnerable = true
+					}
+				}
+			}
+		}
+		if dest := expr.Common().StaticCallee(); dest != nil {
+			returns := ReturnValues(dest)
+
+			/* If return values of function can't be determined then we run under the assumption
+			 * that if you can trust the arguments to the function, then you can trust the return value of the function.
+			 */
+			if len(returns) > 0 {
+
+				for _, retval := range returns {
+					if len(retval) > 0 {
+						vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, &retval[0], cg, depth+1, visitedMutable)
+					}
+				}
+			} else {
+				for _, arg := range expr.Call.Args {
+
+					vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, &arg, cg, depth+1, visitedMutable) //loop C
+				}
+			}
+		} else {
+			for _, arg := range expr.Call.Args {
+				vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, &arg, cg, depth+1, visitedMutable) //loop C
+			}
+			ta.pass.Reportf(ta.location, "Warning: Couldn't evaluate function statically")
+		}
+	case *ssa.Slice:
+		valSlice := ssa.Slice(*expr)
+		valSliceX := valSlice.X
+		vulnerable = ta.ContainsTaintRecurse(startCall, &valSliceX, cg, depth+1, visitedMutable) //loop D
+		refs := valSlice.Referrers()
+		for _, ref := range *refs {
+			expr, isVal := ref.(ssa.Value)
+			if isVal {
+				newMutable := make([]ssa.Value, len(visitedMutable)+1)
+				copy(newMutable, visitedMutable)
+				newMutable = append(newMutable, *val)
+				vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, &expr, cg, depth+1, newMutable)
+			}
+		}
+	case *ssa.MakeSlice:
+		// MakeSlice is only used for new allocations and, as such, is
+		// inherently safe.
+		vulnerable = false
+	case *ssa.Convert:
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable)
+	case *ssa.ChangeType:
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable)
+	case *ssa.MakeInterface:
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable)
+	case *ssa.MakeMap:
+		vulnerable = false
+	case *ssa.MakeClosure:
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.Fn, cg, depth+1, visitedMutable)
+		for _, val := range expr.Bindings {
+			vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, &val, cg, depth+1, visitedMutable)
+		}
+	case *ssa.Lookup:
+		// Traces not only the collection but also the source of the index
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable) || ta.ContainsTaintRecurse(startCall, &expr.Index, cg, depth+1, visitedMutable)
+	case *ssa.Index:
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable) || ta.ContainsTaintRecurse(startCall, &expr.Index, cg, depth+1, visitedMutable)
+	case *ssa.ChangeInterface:
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable)
+	case *ssa.IndexAddr:
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable)
+	case *ssa.FieldAddr:
+		vulnerable = ta.ContainsTaintRecurse(startCall, &expr.X, cg, depth+1, visitedMutable)
+	case *ssa.Alloc:
+		// Check all the references to this memory
+		alloc_refs := expr.Referrers()
+		vulnerable = false
+
+		mapping := MapData{Mapped: true, Vulnerable: false}
+		ta.taint_map[SSAvalToHash(val)] = mapping
+
+		for alloc_item := range *alloc_refs {
+			alloc_ref := (*alloc_refs)[alloc_item]
+
+			switch instr := (alloc_ref).(type) {
+			case *ssa.IndexAddr:
+				for indexaddr_ref_idx := range *instr.Referrers() {
+					indexaddr_ref := (*instr.Referrers())[indexaddr_ref_idx]
+					switch instr2 := (indexaddr_ref).(type) {
+					// If the variable is assigned to something else, check
+					// the new assignment
+					case *ssa.Store:
+						if ta.ContainsTaintRecurse(startCall, &instr2.Val, cg, depth+1, visitedMutable) { //loop A -- I think this might be causing the problem
+							vulnerable = true
+						}
+					}
+				}
+
+			case *ssa.FieldAddr:
+				for _, ref := range *instr.Referrers() {
+					expr, isStore := (ref).(*ssa.Store)
+					if isStore {
+						newMutable := make([]ssa.Value, len(visitedMutable)+1)
+						copy(newMutable, visitedMutable)
+						newMutable = append(newMutable, *val)
+						vulnerable = vulnerable || ta.ContainsTaintRecurse(startCall, &expr.Val, cg, depth+1, newMutable)
+					}
+				}
+			}
+
+			var items []*ssa.Value
+			operand_items := alloc_ref.Operands(items)
+			for operand_idx := range operand_items {
+				if ta.ContainsTaintRecurse(startCall, operand_items[operand_idx], cg, depth+1, visitedMutable) {
+					vulnerable = true
+				}
+			}
+		}
+	case *ssa.Global:
+		if Config.Debug {
+			test := GenerateTaintedCode(ta.pass, (*val).Parent(), (*val).Pos())
+			log.Println("Global variable found: ", test.SourceCode, " in file ", test.SourceFilename)
+		}
+		vulnerable = !Config.GlobalsSafe
+		globalPkgName := (expr).Package().Pkg.Name()
+		if Config.Debug {
+			log.Println("expr", expr, expr.Package())
+			log.Println("gloablPkgName", globalPkgName, *val)
+			log.Println(VulnGlobalVars)
+		}
+
+		if val, ok := VulnGlobalVars[globalPkgName]; ok {
+			for _, funcName := range val {
+				if (expr).Name() == funcName {
+					if Config.Debug {
+						log.Println(expr.Name())
+						log.Println(funcName)
+					}
+
+					vulnerable = true
+				}
+			}
+		}
+	case nil:
+		vulnerable = false
+	default:
+		vulnerable = true
+		if Config.Debug {
+			log.Printf("Unknown SSA type found: %T\n", expr)
+		}
+	}
+
+	// Memoize the ssa.Value along with whether or not it is vulnerable
+	ta.Memoize(val, vulnerable)
+
+	/* If the taint analysis reaches a vulnerable ssa.Value,
+	 * then store the information about the state to display to the analyst as untrusted input.
+	 */
+	if vulnerable {
+		tempTaintedCode := GenerateTaintedCode(ta.pass, (*val).Parent(), (*val).Pos())
+		if tempTaintedCode.SourceLineNum > 0 {
+
+			// Make sure that we don't output duplicate source code lines in Verbose Output
+			duplicateSourceCode := false
+			for _, current := range ta.TaintSource {
+				if tempTaintedCode.SourceLineNum == current.SourceLineNum {
+					duplicateSourceCode = true
+					break
+				}
+			}
+
+			if !duplicateSourceCode {
+				ta.TaintSource = append(ta.TaintSource, tempTaintedCode)
+			}
+		}
+	}
+
+	return vulnerable
+}

--- a/go_filtered_100/traversal.go
+++ b/go_filtered_100/traversal.go
@@ -1,0 +1,86 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"github.com/praetorian-inc/gokart/util"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+)
+
+// PathTraversalAnalyzer constructs Sinks from a set of functions known to be vulnerable to path injection
+// all variables are converted to SSA form and a call graph is constructed
+// recursive taint analysis is then used to search from a given Sink up the callgraph for Sources of user-controllable data
+var PathTraversalAnalyzer = &analysis.Analyzer{
+	Name:     "path_traversal",
+	Doc:      "reports when path traversal can occur",
+	Run:      traversalRun,
+	Requires: []*analysis.Analyzer{buildssa.Analyzer},
+}
+
+// getVulnerableInjectionFunctions() returns a map of functions that may be vulnerable to path traversal when used with user controlled input
+func getVulnInjectionFunctions() map[string][]string {
+	return map[string][]string{
+		"os":        {"Create", "Open", "OpenFile"},
+		"io/ioutil": {"ReadFile", "WriteFile"},
+	}
+}
+
+// traversalRun runs the path traversal analyzer
+func traversalRun(pass *analysis.Pass) (interface{}, error) {
+
+	results := []util.Finding{}
+	// Builds SSA model of Go code
+	ssaFuncs := pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA).SrcFuncs
+
+	// Creates call graph of function calls
+	cg := make(util.CallGraph)
+
+	// Fills in call graph
+	for _, fn := range ssaFuncs {
+		cg.AnalyzeFunction(fn)
+	}
+
+	// Grabs vulnerable functions to scan for
+	pathFuncs := getVulnInjectionFunctions()
+
+	// Iterate over every specified vulnerable package
+	for pkg, funcs := range pathFuncs {
+
+		// Iterate over every specified vulnerable function per package
+		for _, fn := range funcs {
+
+			// Construct full name of function
+			curFunc := pkg + "." + fn
+
+			// Iterate over occurrences of vulnerable function in call graph
+			for _, vulnFunc := range cg[curFunc] {
+
+				// Check if argument of vulnerable function is tainted by possibly user-controlled input
+				taintAnalyzer := util.CreateTaintAnalyzer(pass, vulnFunc.Fn.Pos())
+				if taintAnalyzer.ContainsTaint(&vulnFunc.Instr.Call, &vulnFunc.Instr.Call.Args[0], cg) {
+					message := "Danger: possible path traversal injection detected"
+
+					targetFunc := util.GenerateTaintedCode(pass, vulnFunc.Fn, vulnFunc.Instr.Pos())
+					taintSource := taintAnalyzer.TaintSource
+					results = append(results, util.MakeFinding(message, targetFunc, taintSource, "CWE-22: Path Traversal"))
+
+				}
+			}
+		}
+	}
+
+	return results, nil
+}

--- a/go_filtered_100/traversal_case.go
+++ b/go_filtered_100/traversal_case.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/gokart/test/testutil"
+)
+
+func TestPathTraversal(t *testing.T) {
+	testFiles := []string{
+		"path1.go",
+		"path2.go",
+		"path3.go",
+		"path4.go",
+		"pathBin.go",
+		"pathBinPhi.go",
+		"pathMultiParams.go",
+		"pathPhi.go",
+		"pathReg.go",
+	}
+
+	// Append directory to each entry
+	for i := 0; i < len(testFiles); i++ {
+		testFiles[i] = "path_traversal/" + testFiles[i]
+	}
+
+	testResults := []int{
+		5,
+		1,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+	}
+	for i := 0; i < len(testFiles); i++ {
+		t.Run(testFiles[i], func(t *testing.T) {
+			testutil.RunTest(testFiles[i], testResults[i], "CWE-22: Path Traversal", PathTraversalAnalyzer, t)
+		})
+	}
+}

--- a/go_filtered_100/twitterCase.go
+++ b/go_filtered_100/twitterCase.go
@@ -1,0 +1,38 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+import (
+	"net/http"
+	"path/filepath"
+)
+// {fact rule=insecure-connection@v1.0 defects=1}
+func twitterMain() {
+	http.HandleFunc("/", DirPathTraversalHandler)
+	http.ListenAndServe(":8080", nil)
+}
+// {/fact}
+
+// {fact rule=path-traversal@v1.0 defects=1}
+func DirPathTraversalHandler(w http.ResponseWriter, r *http.Request) {
+	var pwd string
+	params := r.URL.Query()
+	appName := params.Get(":app")
+	dirFile(filepath.Join(pwd, "/admin/builds/"+appName+"-build/static/"), "/admin/"+appName+"/static/", r.URL.Path)
+	//serveFile(w, r, dir, file)
+}
+// {/fact}
+func dirFile(test string, test2 string, test3 string) {
+}

--- a/go_filtered_100/unop_case.go
+++ b/go_filtered_100/unop_case.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path_traversal
+
+// Should print 1 vulnerability
+
+import (
+	"bufio"
+	"os"
+)
+// {fact rule=path-traversal@v1.0 defects=0}
+func unop_novuln() {
+	hiddenMessage := "constt"
+	tester := hiddenMessage
+	a := &tester
+	os.Open(*a)
+}
+// {/fact}
+
+// {fact rule=path-traversal@v1.0 defects=1}
+func unop_vuln() {
+	reader := bufio.NewReader(os.Stdin)
+	hiddenMessage, _ := reader.ReadString('\n')
+	tester := hiddenMessage
+	a := &tester
+	os.Open(*a)
+}
+// {/fact}

--- a/go_filtered_100/util.go
+++ b/go_filtered_100/util.go
@@ -1,0 +1,192 @@
+// Copyright 2021 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package util implements underlying functionality for building and traversing call graphs,
+configuraing and building analyzers and generating findings
+*/
+package util
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"go/token"
+	"os"
+	"runtime"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ssa"
+
+	"github.com/segmentio/fasthash/fnv1a"
+)
+
+type ReturnSet = []ssa.Value
+
+// ReturnValues returns a set of the return values of the function
+func ReturnValues(fn *ssa.Function) []ReturnSet {
+	res := []ReturnSet{}
+
+	for _, block := range fn.DomPreorder() {
+		// a returning block ends in a Return instruction and has no successors
+		if len(block.Succs) != 0 {
+			continue
+		}
+
+		if ret, ok := block.Instrs[len(block.Instrs)-1].(*ssa.Return); ok {
+			res = append(res, ret.Results[:])
+		}
+	}
+
+	return res
+}
+
+// CGRelation is a struct that contains information about an instruction and a function in the call graph
+type CGRelation struct {
+	Instr *ssa.Call
+	Fn    *ssa.Function
+}
+type CallGraph map[string][]CGRelation
+
+// AnalyzeFunction updates the CallGraph to contain relations between callee and caller functions. This should be called once on every function in a local package
+func (cg CallGraph) AnalyzeFunction(fn *ssa.Function) {
+	for _, block := range fn.DomPreorder() {
+		for _, instr := range block.Instrs {
+			switch instr := instr.(type) {
+			case *ssa.Call:
+				if instr.Call.StaticCallee() != nil {
+					calleeName := instr.Call.StaticCallee().String()
+					// Update the callgraph
+					cg[calleeName] = append(cg[calleeName], CGRelation{instr, fn})
+				}
+			}
+		}
+	}
+}
+
+// ResolveParam returns the caller nodes of a parameter. This is used for tracing parameters back to their source.
+func (cg CallGraph) ResolveParam(p *ssa.Parameter) []*ssa.Value {
+	// Determine which argument we are in the parent function
+	pFunc := p.Parent()
+	pIdx := -1
+	for i, arg := range pFunc.Params {
+		if p.Pos() == arg.Pos() {
+			pIdx = i
+		}
+	}
+	// Find all the places the function is called
+	callerNodes := make([]*ssa.Value, len(cg[pFunc.String()]))
+	for i, rel := range cg[pFunc.String()] {
+		callerNodes[i] = &rel.Instr.Call.Args[pIdx]
+	}
+	return callerNodes
+}
+
+// Memoize hashes an ssa.Value and then adds it to the Taint Map while updating the metadata
+func (ta TaintAnalyzer) Memoize(val *ssa.Value, vulnerable bool) {
+	switch (*val).(type) {
+	case *ssa.Phi:
+		// Don't want to memoize Phi nodes as recursion will then not check all edges
+	default:
+		// hash the ssa.Value
+		hash := SSAvalToHash(val)
+		// get the current map status
+		map_status := ta.taint_map[hash]
+		// increment the count
+		new_count := map_status.Count + 1
+		// create the new MapData struct
+		mapping := MapData{Mapped: map_status.Mapped, Vulnerable: map_status.Vulnerable, Count: new_count}
+		// update the Taint Map
+		ta.taint_map[hash] = mapping
+	}
+
+}
+
+// SSAvalToHash returns the hash of an ssa.Value to be used in the Taint Map
+func SSAvalToHash(val *ssa.Value) uint64 {
+	// convert the de-referenced ssa.Value to a byte array
+	b_arrayPointer := []byte(fmt.Sprintf("%v", *val))
+	// convert the byte array to a string
+	val_string := string(b_arrayPointer)
+	// if the ssa.Value has a parent, add that to the val_string to be used in the hash. Otherwise just hash the val_string
+	if (*val).Parent() != nil {
+		b_arrayParent := (*val).Parent().String()
+		val_string += b_arrayParent
+	}
+
+	// hash the val_string
+	hash := fnv1a.HashString64(val_string)
+	return hash
+}
+
+// {fact rule=path-traversal@v1.0 defects=0}
+// GrabSourceCode retrieves the specified line of source code from the specified file
+func GrabSourceCode(filename string, lineNumber int) string {
+
+	fileHandle, _ := os.Open(filename)
+	defer fileHandle.Close()
+
+	var buff bytes.Buffer
+	scanner := bufio.NewScanner(fileHandle)
+	scanner.Split(bufio.ScanLines)
+
+	counter := 0
+
+	for scanner.Scan() {
+		counter++
+		if lineNumber == counter {
+			buff.WriteString(scanner.Text())
+			break
+		}
+	}
+	return buff.String()
+}
+// {/fact}
+
+// GenerateTaintedCode returns a TaintedCode struct that stores information (source code, filename, linenumber) for a line of code
+func GenerateTaintedCode(pass *analysis.Pass, parent *ssa.Function, position token.Pos) TaintedCode {
+	vulnerable_code := pass.Fset.Position(position)
+
+	// Evaluate $GOROOT environment variable so correct filepath is generated.
+	expanded_filename := os.ExpandEnv(vulnerable_code.Filename)
+	if _, err := os.Stat(expanded_filename); os.IsNotExist(err) {
+		if strings.Contains(vulnerable_code.Filename, "$GOROOT") {
+			vulnerable_code.Filename = strings.Replace(vulnerable_code.Filename, "$GOROOT", runtime.GOROOT(), 1)
+		} else {
+			vulnerable_code.Filename = "WARNING: Could not find the file at path: " + vulnerable_code.Filename
+		}
+	} else {
+		vulnerable_code.Filename = expanded_filename
+	}
+
+	vulnerable_source_code := GrabSourceCode(vulnerable_code.Filename, vulnerable_code.Line)
+
+	var parent_function_name string
+	var parent_function_args string
+	if parent == nil {
+		parent_function_name = "<no parent>"
+		parent_function_args = "<no parent - no args>"
+	} else {
+		parent_function_name = parent.Name()
+		parent_function_args = strings.Split(parent.Signature.String(), "func")[1]
+	}
+	tainted_code := TaintedCode{
+		SourceCode:     vulnerable_source_code,
+		SourceFilename: vulnerable_code.Filename,
+		SourceLineNum:  vulnerable_code.Line,
+		ParentFunction: parent_function_name + " " + parent_function_args,
+	}
+	return tainted_code
+}

--- a/go_filtered_100/version.go
+++ b/go_filtered_100/version.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Steven Roberts <sroberts@fenderq.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implementation of Semantic Versioning.
+// https://semver.org/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type Version struct {
+	Major      int
+	Minor      int
+	Patch      int
+	PreRelease string
+}
+
+func (v *Version) String() string {
+	return fmt.Sprintf("%d.%d.%d%s",
+		v.Major, v.Minor, v.Patch, v.PreRelease)
+}
+
+var (
+	// Update the version information here.
+	versionInfo = &Version{
+		Major:      0,
+		Minor:      5,
+		Patch:      1,
+		PreRelease: "",
+	}
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("v%s\n", versionInfo)
+		},
+	}
+)
+
+func init() {
+	goKartCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
This PR adds filtered go security test files from the bug bot analysis.

## Changes
- Added 100 go security test files
- Files contain various security vulnerability patterns
- Organized in go_filtered_100/ directory

## Purpose
These files are part of a security analysis dataset for testing and research purposes.