### PR TITLE
Add rust filtered security test files

### DIFF
--- a/rust_filtered_100/args-os.rs
+++ b/rust_filtered_100/args-os.rs
@@ -1,0 +1,6 @@
+use std::env;
+
+// {fact rule=untrusted-data-in-decision@v1.0 defects=1}
+// ruleid: args-os
+let args = env::args_os();
+// {/fact}

--- a/rust_filtered_100/args.rs
+++ b/rust_filtered_100/args.rs
@@ -1,0 +1,6 @@
+use std::env;
+
+// {fact rule=untrusted-data-in-decision@v1.0 defects=1}
+// ruleid: args
+let args = env::args();
+// {/fact}

--- a/rust_filtered_100/compliant.rs
+++ b/rust_filtered_100/compliant.rs
@@ -1,0 +1,12 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=insecure-connection@v1.0 defects=0}
+// Compliant: Used suppaftp for connection
+use suppaftp::FtpStream;
+
+	 let mut ftp_stream = FtpStream::connect("example.com").unwrap();
+	 ftp_stream.login("anonymous", "me@example.com").unwrap();
+// {/fact}

--- a/rust_filtered_100/compliant_1.rs
+++ b/rust_filtered_100/compliant_1.rs
@@ -1,0 +1,18 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=out-of-bounds-read@v1.0 defects=0}
+// Compliant: Safe access within array bounds and incorrect condition check.
+    fn compliant() {
+        let numbers = vec![1, 2, 3, 4, 5];
+
+        unsafe {
+            for i in 0..4 {
+                let value = numbers.get_unchecked(i);
+                println!("Value: {}", value);
+            }
+        }
+    }
+// {/fact}

--- a/rust_filtered_100/compliant_10.rs
+++ b/rust_filtered_100/compliant_10.rs
@@ -1,0 +1,12 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=sql-injection@v1.0 defects=0}
+// Compliant: Uses parameterized queries to safely handle user input.
+    fn get_user(conn: &Connection, username: &str) -> Result<User, Error> {
+        conn.query_row("SELECT * FROM users WHERE username = ?", [username], |row| {
+        })
+    }
+// {/fact}

--- a/rust_filtered_100/compliant_11.rs
+++ b/rust_filtered_100/compliant_11.rs
@@ -1,0 +1,18 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=use-of-uninitialized-variable@v1.0 defects=0}
+// Compliant: `MaybeUninit` and following proper initialization procedures within an `unsafe` block
+use std::mem::MaybeUninit;
+
+   fn compliant() {
+   	     let mut value = MaybeUninit::<i32>::uninit();
+   	     unsafe {
+   	         value.as_mut_ptr().write(0);
+   	         let value = value.assume_init();
+   	         println!("Value: {}", value);
+   	     }
+   }
+// {/fact}

--- a/rust_filtered_100/compliant_2.rs
+++ b/rust_filtered_100/compliant_2.rs
@@ -1,0 +1,11 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=cross-site-scripting@v1.0 defects=0}
+// Compliant: Safely encodes user input using `encode_safe`.
+    let user_input = request.query("user_input");
+    let html = format!("<div>{}</div>", encode_safe(&user_input));
+    response.set_body(html)
+// {/fact}

--- a/rust_filtered_100/compliant_3.rs
+++ b/rust_filtered_100/compliant_3.rs
@@ -1,0 +1,10 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=insecure-hashing@v1.0 defects=0}
+// Compliant: secured hasing algorithm `Sha256` used
+   use sha256::{Sha256};
+   let mut hasher = Sha256::new();
+// {/fact}

--- a/rust_filtered_100/compliant_4.rs
+++ b/rust_filtered_100/compliant_4.rs
@@ -1,0 +1,14 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=os-command-injection@v1.0 defects=0}
+// Compliant: string arguments instead of user input
+    fn compliant2() {
+	     let output = Command::new("ls")
+	         .arg("-l")
+	         .output()
+	         .expect("failed to execute process");
+	 }
+// {/fact}

--- a/rust_filtered_100/compliant_5.rs
+++ b/rust_filtered_100/compliant_5.rs
@@ -1,0 +1,13 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=thread-safety-violation@v1.0 defects=0}
+// Compliant: Uses `tokio::task::spawn_blocking` to perform file reading in a separate blocking thread
+    async fn read_file_blocking(file_path: &str) -> String {
+        tokio::task::spawn_blocking(move || {
+            net::read_to_string(file_path).unwrap()
+        }).await.unwrap()
+    }
+// {/fact}

--- a/rust_filtered_100/compliant_6.rs
+++ b/rust_filtered_100/compliant_6.rs
@@ -1,0 +1,11 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=improper-certificate-validation@v1.0 defects=0}
+// Compliant: ssl verification is enabled
+use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+let mut connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
+connector.builder_mut().set_verify(SSL_VERIFY_PEER);
+// {/fact}

--- a/rust_filtered_100/compliant_7.rs
+++ b/rust_filtered_100/compliant_7.rs
@@ -1,0 +1,13 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=classic-buffer-overflow@v1.0 defects=0}
+// Compliant: Safely converts a u32.
+    fn compliant() {
+        let num: u32 = 12345;
+        let bytes: [u8; 4] = num.to_le_bytes(); 
+        println!("{:?}", bytes);
+    }
+// {/fact}

--- a/rust_filtered_100/compliant_8.rs
+++ b/rust_filtered_100/compliant_8.rs
@@ -1,0 +1,10 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=weak-random-number-generation@v1.0 defects=0}
+// Compliant: Secure random number generators
+    let key = ring::aead::LessSafeKey::new(unbound_key);
+	let rng = ring::rand::SystemRandom::new();
+// {/fact}

--- a/rust_filtered_100/compliant_9.rs
+++ b/rust_filtered_100/compliant_9.rs
@@ -1,0 +1,15 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=out-of-bounds-write@v1.0 defects=0}
+// Compliant: Safe access within array bounds and incorrect condition check.
+    fn compliant() {
+        let mut arr = [0; 5];
+        let index = 10;
+        if index < arr.len() {
+            arr[index] = 42;
+        }
+    }
+// {/fact}

--- a/rust_filtered_100/current-exe.rs
+++ b/rust_filtered_100/current-exe.rs
@@ -1,0 +1,6 @@
+use std::env;
+
+// {fact rule=untrusted-data-in-decision@v1.0 defects=1}
+// ruleid: current-exe
+let exe = env::current_exe();
+// {/fact}

--- a/rust_filtered_100/insecure-hashes.rs
+++ b/rust_filtered_100/insecure-hashes.rs
@@ -1,0 +1,30 @@
+use md2::{Md2};
+use md4::{Md4};
+use md5::{Md5};
+use sha1::{Sha1};
+use sha2::{Sha256};
+
+// {fact rule=insecure-hashing@v1.0 defects=1}
+// ruleid: insecure-hashes
+let mut hasher = Md2::new();
+// {/fact}
+
+// {fact rule=insecure-hashing@v1.0 defects=1}
+// ruleid: insecure-hashes
+let mut hasher = Md4::new();
+// {/fact}
+
+// {fact rule=insecure-hashing@v1.0 defects=1}
+// ruleid: insecure-hashes
+let mut hasher = Md5::new();
+// {/fact}
+
+// {fact rule=insecure-hashing@v1.0 defects=1}
+// ruleid: insecure-hashes
+let mut hasher = Sha1::new();
+// {/fact}
+
+// {fact rule=insecure-hashing@v1.0 defects=0}
+// ok: insecure-hashes
+let mut hasher = Sha256::new();
+// {/fact}

--- a/rust_filtered_100/non-compliant.rs
+++ b/rust_filtered_100/non-compliant.rs
@@ -1,0 +1,13 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=insecure-connection@v1.0 defects=1}
+
+use ftp::{FtpError, FtpStream};
+use std::{io::Cursor, str};
+// Noncompliant: ftp crate is not maintained any more
+	 let mut ftp_stream = FtpStream::connect((addr, 21)).unwrap();
+	 let _ = ftp_stream.login("Doe", "mumble").unwrap();
+// {/fact}

--- a/rust_filtered_100/non-compliant_1.rs
+++ b/rust_filtered_100/non-compliant_1.rs
@@ -1,0 +1,16 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=out-of-bounds-read@v1.0 defects=1}
+// Noncompliant: Out of bounds read can lead to undefined behavior. 
+	fn noncompliant() {
+		let numbers = vec![1, 2, 3, 4, 5];
+		let index = 10;  
+		unsafe {
+			let value = numbers.get_unchecked(index);
+			println!("Value: {}", value);
+		}
+	}
+// {/fact}

--- a/rust_filtered_100/non-compliant_10.rs
+++ b/rust_filtered_100/non-compliant_10.rs
@@ -1,0 +1,16 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=sql-injection@v1.0 defects=1}
+// Noncompliant: Constructs a SQL query using string interpolation.
+    fn get_user(conn: &Connection, username: &str) -> Result<User, Error> {
+        let query = format!("
+            SELECT * FROM products 
+            WHERE name LIKE '%{}%' OR description LIKE '%{}%'
+        ", username);
+        conn.query_row(&query, [], |row| {
+        })
+    }
+// {/fact} 

--- a/rust_filtered_100/non-compliant_11.rs
+++ b/rust_filtered_100/non-compliant_11.rs
@@ -1,0 +1,9 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=use-of-uninitialized-variable@v1.0 defects=1}
+// Noncompliant: The `std::mem::uninitialized()` function was deprecated in Rust
+  let value: i32 = std::mem::uninitialized();
+// {/fact}

--- a/rust_filtered_100/non-compliant_2.rs
+++ b/rust_filtered_100/non-compliant_2.rs
@@ -1,0 +1,11 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=cross-site-scripting@v1.0 defects=1}
+// Noncompliant: Directly includes user input in HTML without encoding.
+    let user_input = request.query("user_input");
+    let html = format!("<div>{}</div>", &user_input);
+    response.set_body(html)
+// {/fact} 

--- a/rust_filtered_100/non-compliant_3.rs
+++ b/rust_filtered_100/non-compliant_3.rs
@@ -1,0 +1,10 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=insecure-hashing@v1.0 defects=1}
+// Noncompliant: Insecure hashing algorithm `Md2` used
+   use md2::{Md2};
+   let mut hasher = Md2::new();
+// {/fact}

--- a/rust_filtered_100/non-compliant_4.rs
+++ b/rust_filtered_100/non-compliant_4.rs
@@ -1,0 +1,18 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=os-command-injection@v1.0 defects=1}
+// Noncompliant: User input without proper validation
+    fn noncompliant() {
+    	     println!("Enter a command:");
+    	     let mut input = String::new();
+    	     io::stdin().read_line(&mut input).expect("Failed to read input");
+    	     let output = Command::new("sh")
+    	       .arg("-c")
+    	       .arg(input.trim())
+    	       .output()
+    	       .expect("failed to execute process");
+    	 }
+// {/fact}

--- a/rust_filtered_100/non-compliant_5.rs
+++ b/rust_filtered_100/non-compliant_5.rs
@@ -1,0 +1,13 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=thread-safety-violation@v1.0 defects=1}
+// Noncompliant: Performing a blocking file write operation within an asynchronous function without proper safeguards.
+    async fn write_to_file_blocking(file_path: &str, content: &str) {
+        task::spawn_blocking(move || {
+            fs::write(file_path, content).unwrap();
+        }).await.unwrap();
+    }
+// {/fact} 

--- a/rust_filtered_100/non-compliant_6.rs
+++ b/rust_filtered_100/non-compliant_6.rs
@@ -1,0 +1,11 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=improper-certificate-validation@v1.0 defects=1}
+// Noncompliant: ssl verification is disabled
+use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+let mut connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
+connector.builder_mut().set_verify(SSL_VERIFY_NONE);
+// {/fact}

--- a/rust_filtered_100/non-compliant_7.rs
+++ b/rust_filtered_100/non-compliant_7.rs
@@ -1,0 +1,13 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=classic-buffer-overflow@v1.0 defects=1}
+// Noncompliant: Uses unsafe `mem::transmute` to convert a u32.
+    fn noncompliant() {
+        let num: u32 = 12345;
+        let bytes: [u8; 4] = unsafe { mem::transmute(num) }; 
+        println!("{:?}", bytes);
+    }
+// {/fact} 

--- a/rust_filtered_100/non-compliant_8.rs
+++ b/rust_filtered_100/non-compliant_8.rs
@@ -1,0 +1,12 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=weak-random-number-generation@v1.0 defects=1}
+// Noncompliant: Weak random number generators `seed_from_u64`
+    let mut rng = StdRng::seed_from_u64(42);
+  	 for _ in 0..10 {
+  	         let random_number: u32 = rng.gen();
+  	 }
+// {/fact}

--- a/rust_filtered_100/non-compliant_9.rs
+++ b/rust_filtered_100/non-compliant_9.rs
@@ -1,0 +1,15 @@
+/*
+*  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*  SPDX-License-Identifier: Apache-2.0
+*/
+
+// {fact rule=out-of-bounds-write@v1.0 defects=1}
+// Noncompliant: Out of bounds write can lead to undefined behavior. 
+	fn noncompliant() {
+		let mut arr = [0; 5];
+		let i =6;
+		unsafe {
+			arr.get_unchecked_mut(i) = i;
+		}
+	}
+// {/fact}

--- a/rust_filtered_100/reqwest-accept-invalid.rs
+++ b/rust_filtered_100/reqwest-accept-invalid.rs
@@ -1,0 +1,37 @@
+use reqwest::header;
+
+// {fact rule=improper-certificate-validation@v1.0 defects=1}
+// ruleid: reqwest-accept-invalid
+let client = reqwest::Client::builder()
+    .danger_accept_invalid_hostnames(true)
+    .build();
+// {/fact}
+
+// {fact rule=improper-certificate-validation@v1.0 defects=1}
+// ruleid: reqwest-accept-invalid
+let client = reqwest::Client::builder()
+    .danger_accept_invalid_certs(true)
+    .build();
+// {/fact}
+// {fact rule=improper-certificate-validation@v1.0 defects=1}
+// ruleid: reqwest-accept-invalid
+let client = reqwest::Client::builder()
+    .user_agent("USER AGENT")
+    .cookie_store(true)
+    .danger_accept_invalid_hostnames(true)
+    .build();
+// {/fact}
+// {fact rule=improper-certificate-validation@v1.0 defects=1}
+// ruleid: reqwest-accept-invalid
+let client = reqwest::Client::builder()
+    .user_agent("USER AGENT")
+    .cookie_store(true)
+    .danger_accept_invalid_certs(true)
+    .build();
+// {/fact}
+// {fact rule=improper-certificate-validation@v1.0 defects=0}
+// ok: reqwest-accept-invalid
+let client = reqwest::Client::builder()
+    .user_agent("USER AGENT")
+    .build();
+// {/fact}

--- a/rust_filtered_100/reqwest-set-sensitive.rs
+++ b/rust_filtered_100/reqwest-set-sensitive.rs
@@ -1,0 +1,43 @@
+use reqwest::header;
+use reqwest::{blocking::Client, header::HeaderMap, header::HeaderValue, Url};
+
+// {fact rule=request-set-sensitive@v1.0 defects=1}
+// ruleid: reqwest-set-sensitive
+let mut headers = header::HeaderMap::new();
+let header = header::HeaderValue::from_static("secret");
+headers.insert(header::AUTHORIZATION, header);
+// {/fact}
+
+// {fact rule=request-set-sensitive@v1.0 defects=1}
+// ruleid: reqwest-set-sensitive
+let mut headers = header::HeaderMap::new();
+let header = header::HeaderValue::from_static("secret");
+headers.insert("Authorization", header);
+// {/fact}
+
+// {fact rule=request-set-sensitive@v1.0 defects=1}
+// ruleid: reqwest-set-sensitive
+let mut headers = header::HeaderMap::new();
+let header = header::HeaderValue::from_static("secret").map_err(|e| {
+    Error::Generic(format!(
+        "Error"
+    ))
+});
+headers.insert(header::AUTHORIZATION, header);
+// {/fact}
+
+// {fact rule=request-set-sensitive@v1.0 defects=1}
+// Remove todo when Rust supports import equivalence
+// todoruleid: reqwest-set-sensitive
+let mut headers = HeaderMap::new();
+let header = HeaderValue::from_static("secret");
+headers.insert(header::AUTHORIZATION, header);
+// {/fact}
+
+// {fact rule=request-set-sensitive@v1.0 defects=0}
+// ok: reqwest-set-sensitive
+let mut headers = header::HeaderMap::new();
+let header = header::HeaderValue::from_static("secret");
+header.set_sensitive(true);
+headers.insert(header::AUTHORIZATION, header);
+// {/fact}

--- a/rust_filtered_100/rustls-dangerous.rs
+++ b/rust_filtered_100/rustls-dangerous.rs
@@ -1,0 +1,27 @@
+use rustls::{RootCertStore, Certificate, ServerCertVerified, TLSError, ServerCertVerifier};
+
+let verifier = MyServerCertVerifie;
+
+// {fact rule=improper-certificate-validation@v1.0 defects=0}
+// ok: rustls-dangerous
+let mut c1 = rustls::client::ClientConfig::new();
+// {/fact}
+
+// {fact rule=improper-certificate-validation@v1.0 defects=1}
+// Remove todo when Rust supports direct module references
+// ruleid: rustls-dangerous
+let mut c2 = rustls::client::DangerousClientConfig {cfg: &mut cfg};
+c2.set_certificate_verifier(verifier);
+// {/fact}
+
+// {fact rule=improper-certificate-validation@v1.0 defects=1}
+let mut c3 = rustls::client::ClientConfig::new();
+// ruleid: rustls-dangerous
+c3.dangerous().set_certificate_verifier(verifier);
+// {/fact}
+
+// {fact rule=improper-certificate-validation@v1.0 defects=1}
+// ruleid: rustls-dangerous
+let mut c4 = rustls::client::ClientConfig::dangerous(&mut ());
+c4.set_certificate_verifier(verifier);
+// {/fact}

--- a/rust_filtered_100/ssl-verify-none.rs
+++ b/rust_filtered_100/ssl-verify-none.rs
@@ -1,0 +1,15 @@
+use openssl::ssl::{SslMethod, SslConnectorBuilder, SSL_VERIFY_NONE};
+
+let mut connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
+
+// {fact rule=improper-certificate-validation@v1.0 defects=1}
+// ruleid: ssl-verify-none
+connector.builder_mut().set_verify(SSL_VERIFY_NONE);
+// {/fact}
+
+// {fact rule=improper-certificate-validation@v1.0 defects=0}
+// ok: ssl-verify-none
+connector.builder_mut().set_verify(SSL_VERIFY_PEER);
+// {/fact}
+
+let openssl = OpenSsl::from(connector.build());

--- a/rust_filtered_100/temp-dir.rs
+++ b/rust_filtered_100/temp-dir.rs
@@ -1,0 +1,6 @@
+use std::env;
+
+// {fact rule=untrusted-data-in-decision@v1.0 defects=1}
+// ruleid: temp-dir
+let dir = env::temp_dir();
+// {/fact}

--- a/rust_filtered_100/unsafe-usage.rs
+++ b/rust_filtered_100/unsafe-usage.rs
@@ -1,0 +1,9 @@
+// {fact rule=inherently-dangerous-function@v1.0 defects=1}
+// ruleid: unsafe-usage
+let pid = unsafe { libc::getpid() as u32 };
+// {/fact}
+
+// {fact rule=inherently-dangerous-function@v1.0 defects=0}
+// ok: unsafe-usage
+let pid = libc::getpid() as u32;
+// {/fact}


### PR DESCRIPTION
This PR adds filtered rust security test files from the bug bot analysis.

## Changes
- Added 100 rust security test files
- Files contain various security vulnerability patterns
- Organized in rust_filtered_100/ directory

## Purpose
These files are part of a security analysis dataset for testing and research purposes.